### PR TITLE
#40 Feature to add virtual network to Terraform template for shared services

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -9,9 +9,11 @@
 
 ## Resources
 
-The following respources will be deployed
+The following resources will be deployed
 - Azure Resource Group
 - Azure KeyVault 
+- Azure Virtual Network
+- Azure Subnet
 
 ## Deployment
 

--- a/shared/main.tf
+++ b/shared/main.tf
@@ -71,7 +71,7 @@ resource "azurerm_key_vault" "keyvault" {
 
 resource "azurerm_virtual_network" "vnet" {
   name                 = "core-${local.location_suffix}-vnet-${var.company}"
-  address_space        = ["10.0.0.0/16"]
+  address_space        = ["${var.virtual_network_address_space}"]
   location             = "${azurerm_resource_group.rg_core.location}"
   resource_group_name  = "${azurerm_resource_group.rg_core.name}"
 }
@@ -80,5 +80,5 @@ resource "azurerm_subnet" "subnet" {
   name                 = "core-${local.location_suffix}-subnet-${var.company}"
   resource_group_name  = "${azurerm_resource_group.rg_core.name}"
   virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  address_prefix       = "10.0.1.0/24"
+  address_prefix       = "${var.subnet_address_prefix}"
 }

--- a/shared/main.tf
+++ b/shared/main.tf
@@ -68,3 +68,17 @@ resource "azurerm_key_vault" "keyvault" {
     bypass         = "AzureServices"
   }
 }
+
+resource "azurerm_virtual_network" "vnet" {
+  name                 = "core-${local.location_suffix}-vnet-${var.company}"
+  address_space        = ["10.0.0.0/16"]
+  location             = "${azurerm_resource_group.rg_core.location}"
+  resource_group_name  = "${azurerm_resource_group.rg_core.name}"
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "core-${local.location_suffix}-subnet-${var.company}"
+  resource_group_name  = "${azurerm_resource_group.rg_core.name}"
+  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
+  address_prefix       = "10.0.1.0/24"
+}

--- a/shared/variables.tf
+++ b/shared/variables.tf
@@ -13,3 +13,15 @@ variable "keyvault_sku" {
   description = "SKU of the keyvault to create"
   default     = "standard"
 }
+
+variable "virtual_network_address_space" {
+    type = "string",
+    description = "The virtual network address space"
+    default = "10.0.0.0/16"
+}
+
+variable "subnet_address_prefix" {
+    type = "string",
+    description = "The virtual network subnet address prefix"
+    default = "10.0.1.0/24"
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. ./assert.sh continue_on_error     # Load test functions with continue_on_error/stop_on_error
+
+. ./vnet_test/main.sh               # Tests for virtual network and subnet

--- a/tests/vnet_test/main.sh
+++ b/tests/vnet_test/main.sh
@@ -14,7 +14,7 @@ assertRG core-usea-rg-test not
 terraform init ../../shared/
 terraform apply -auto-approve ../../shared/
 
-#Check if resource group exists
+#Check if resource group was created
 assertRG core-usea-rg-test
 
 #Check if virtual network exists

--- a/tests/vnet_test/main.sh
+++ b/tests/vnet_test/main.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-. ../assert.sh continue_on_error #  load test functions with continue_on_error/stop_on_error
+#. ../assert.sh continue_on_error #  load test functions with continue_on_error/stop_on_error
 
 export TF_VAR_location=eastus
 export TF_VAR_company=test
@@ -11,8 +11,8 @@ export TF_VAR_company=test
 assertRG core-usea-rg-test not
 
 #Deploy all the test resources
-terraform init ../../shared/
-terraform apply -auto-approve ../../shared/
+terraform init ../shared/
+terraform apply -auto-approve ../shared/
 
 #Check if resource group was created
 assertRG core-usea-rg-test
@@ -24,4 +24,4 @@ assertResource core-usea-rg-test "Microsoft.Network/virtualNetworks" core-usea-v
 assertSubnet core-usea-rg-test core-usea-vnet-test core-usea-subnet-test
 
 #Destroy the test resources
-terraform destroy -auto-approve ../../shared/
+terraform destroy -auto-approve ../shared/

--- a/tests/vnet_test/main.sh
+++ b/tests/vnet_test/main.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+. ../assert.sh continue_on_error #  load test functions with continue_on_error/stop_on_error
+
+export TF_VAR_location=eastus
+export TF_VAR_company=test
+
+#Check if resource group exists
+#Resource group does not exists at this point
+assertRG core-usea-rg-test not
+
+#Deploy all the test resources
+terraform init ../../shared/
+terraform apply -auto-approve ../../shared/
+
+#Check if resource group exists
+assertRG core-usea-rg-test
+
+#Check if virtual network exists
+assertResource core-usea-rg-test "Microsoft.Network/virtualNetworks" core-usea-vnet-test
+
+#Check if subnet exists inside virtual network
+assertSubnet core-usea-rg-test core-usea-vnet-test core-usea-subnet-test
+
+#Destroy the test resources
+terraform destroy -auto-approve ../../shared/


### PR DESCRIPTION
PR for Issue: https://github.com/Microsoft/entref-appservice-containers/issues/40

As an IT admin or developer, I can now provision a virtual network as a resource in the shared/core services, so that I can provision additional resources that require an existing virtual network.

This PR is dependent on the base test framework in #45 (assert.sh) as it adds unit tests to test virtual network and subnet created using the template.