### PR TITLE
Adding docker test base image

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,16 @@
+# Resource Deployment Testing in Cobalt
+
+## Summary
+
+This section describes how to build integration and validation tests for your cobalt deployment environments using the terratest modules.
+
+Terratest is a Go library that makes it easier to write automated tests for your infrastructure code. It provides a variety of helper functions and patterns for common infrastructure testing tasks.
+
+In addition, the cobalt test suite allows for better collaboration with embedding into CI/CD tools such as Travis or Azure DevOps Pipelines.
+
+## Prerequisites
+- [Docker](https://docs.docker.com/install/) 18.09 or later
+
+## Test Setup Locally
+
+In this example we are using the [`azure-simple`](/infra/templates/azure-simple/readme.md) for a template integration test.

--- a/test/docker/base-images/Dockerfile
+++ b/test/docker/base-images/Dockerfile
@@ -1,0 +1,34 @@
+ARG gover
+FROM golang:$gover
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y git curl apt-transport-https lsb-release gpg
+
+# Install Azure CLI
+RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
+    gpg --dearmor | \
+    tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
+
+RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" | \
+    tee /etc/apt/sources.list.d/azure-cli.list
+RUN apt-get update
+
+RUN apt-get install -y azure-cli
+# Set go bin which doesn't appear to be set already.
+ENV GOBIN /go/bin
+
+RUN mkdir /app
+RUN mkdir /go/src/app
+#ADD . /go/src/app
+
+# Go dep!
+RUN go get -u github.com/golang/dep/...
+
+# Go Mage!
+RUN go get -u github.com/magefile/mage
+WORKDIR $GOPATH/src/github.com/magefile/mage
+RUN go run bootstrap.go
+
+WORKDIR /go/src/app
+CMD bash

--- a/test/docker/base-images/README.md
+++ b/test/docker/base-images/README.md
@@ -1,0 +1,42 @@
+# Cobalt Test Base Image
+
+This is the base image used for running terratest based unit and integration GO tests. This image comes pre-packaged with the following dependencies:
+* Go programming language: Terraform test cases are written in [Go](https://golang.org/dl/).
+* dep: [dep](https://github.com/golang/dep#installation) is a dependency management tool for Go.
+* Azure CLI: The [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) is a command-line tool you can use to manage Azure resources. (Terraform supports authenticating to Azure through a service principal or via the Azure CLI.)
+* mage: We use the mage go [module](https://github.com/magefile/mage#installation) to show you how to simplify running Terratest cases.
+
+## Getting Started
+
+You can build this image locally using a different golang version following the example below.
+
+### Prerequisities
+
+In order to run this container you'll need docker installed.
+
+* [Windows](https://docs.docker.com/windows/started)
+* [OS X](https://docs.docker.com/mac/started/)
+* [Linux](https://docs.docker.com/linux/started/)
+
+### Usage
+
+#### Image Build Parameters
+
+**govver**
+
+Golang version specification. This argument drives which golang version this image will use off the `golang` stretch base image.
+
+```shell
+docker build -f "test\docker\base-images\Dockerfile" -t msftcse/cobalt-test-base:1.11 . --build-arg gover=1.11
+```
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Authors
+
+* [@erikschlegel](https://github.com/erikschlegel)
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.


### PR DESCRIPTION
**Description**
This pull request adds a base docker image for [terratest](https://github.com/gruntwork-io/terratest)  integration and unit tests. These automated tests will be triggered throughout cobalt continuous integration builds. The test base image comes pre-packaged with mage, go version 1.11, dep and azure cli. 

This PR covers the following features.

* Added a `README` in the root `test` directory.
* Added the `dockerfile` for the test base image. 
* Added a `README` within the `test/docker/base-images/` folder
* Pushed the base image to docker hub for golang 1.11.

**User Story**
This closes #55 

**Story Completion evidence**
Pushed a base image using golang version 1.11 to docker hub within the [msftcse/cobalt-test-base](https://cloud.docker.com/u/msftcse/repository/docker/msftcse/cobalt-test-base) repository. 