### PR TITLE
Service Principal Default Name Bug

### DIFF
--- a/infra/modules/providers/azure/service-principal/variables.tf
+++ b/infra/modules/providers/azure/service-principal/variables.tf
@@ -1,20 +1,3 @@
-variable "create_for_rbac" {
-  description = "Create a new Service Principle"
-  type        = bool
-  default     = false
-}
-
-variable "display_name" {
-  description = "Display name of the AD application"
-  type        = string
-}
-
-variable "object_id" {
-  description = "Object Id of the service principle to assign a role"
-  type        = string
-  default     = ""
-}
-
 variable "role_name" {
   description = "The name of the role definition to assign a service principle too."
   type        = string
@@ -25,3 +8,20 @@ variable "role_scope" {
   type        = string
 }
 
+variable "create_for_rbac" {
+  description = "Create a new Service Principle"
+  type        = bool
+  default     = false
+}
+
+variable "display_name" {
+  description = "Display name of the AD application"
+  type        = string
+  default     = "AD Client"
+}
+
+variable "object_id" {
+  description = "Object Id of the service principle to assign a role"
+  type        = string
+  default     = ""
+}

--- a/infra/modules/providers/azure/service-principal/variables.tf
+++ b/infra/modules/providers/azure/service-principal/variables.tf
@@ -17,7 +17,7 @@ variable "create_for_rbac" {
 variable "display_name" {
   description = "Display name of the AD application"
   type        = string
-  default     = "AD Client"
+  default     = ""
 }
 
 variable "object_id" {


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [NO] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #182 


## What is the new behavior?
-------------------------------------
<!-- Please describe the behavior or changes that are being added by this PR. -->

Service Principal module now has a default name for 'display name' variable when creating new service principals. 

Users of the module passing in 'existing service principals' no longer have to pass in a value intended for 'new service principal' scenarios. .

## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
-------------------------------------
Required vars have been moved to the top of the script.

## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
![image](https://user-images.githubusercontent.com/10041279/59851380-2468b300-9332-11e9-9d1f-034e1af3e03e.png)

