### PR TITLE
Add technical design for making authenticated requests during integration tests

### DIFF
--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -29,6 +29,29 @@ ref: [Service to service calls using client credentials](https://docs.microsoft.
 
 ![image](https://user-images.githubusercontent.com/17349002/61076671-c7b95f00-a3ea-11e9-8361-205ed088d0f6.png)
 
+# Authorizer Function
+
+Currently there is a working function that provides the functionality needed to obtain a valid bearer token. This will be used as the "Authorizer" function referenced in the swim lane diagram above.
+
+```go
+// ServicePrincipalAuthorizer - Configures a service principal authorizer that can be used to create bearer tokens
+func ServicePrincipalAuthorizer(clientID string, clientSecret string, resource string) (autorest.Authorizer, error) {
+	oauthConfig, err := adal.NewOAuthConfig(az.PublicCloud.ActiveDirectoryEndpoint, os.Getenv("ARM_TENANT_ID"))
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := adal.NewServicePrincipalToken(*oauthConfig, clientID, clientSecret, resource)
+	if err != nil {
+		return nil, err
+	}
+
+	return autorest.NewBearerAuthorizer(token), nil
+}
+```
+
+ref: [authorizer.go: Lines 19 - 32](https://github.com/microsoft/cobalt/blob/35e73daea4231bd8ded378fc3d386ac06f7e39d7/test-harness/terratest-extensions/modules/azure/authorizer.go#L19-L32)
+
 # Inputs
 
 All inputs are provided to the functions used by the testing framework by the user. The Service Principle Secret should be stored in Key Vault and accessed only at the time of the function call so that it's not stored in memory any longer than needed.

--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -1,0 +1,21 @@
+# Purpose/Description
+
+Users that would like to create integration tests and have an application they would like to verify is deployed but uses Authentication provide by Azure AD, they should have the ability to generate a token in the tests and use it in making the request to the application.
+
+
+
+# Background Information
+
+# Out-of-Scope
+
+# Diagram
+
+# Inputs
+
+SP ID
+SP Secret
+tenant id
+url to test
+multi-tenant
+
+# Outputs

--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -1,20 +1,78 @@
 # Purpose/Description
+<!-- 
+Who is the user?
+What does it do?
+When does a users use this?
+Why does a user want this?
+How does a user use this?
+-->
 
-Users that would like to create integration tests and have an application they would like to verify is deployed but uses Authentication provide by Azure AD, they should have the ability to generate a token in the tests and use it in making the request to the application.
+An engineer wants to get a successful resonse back from an appication using Azure AD based Authentication deployed to Cobalt managed infastrcuture. And/or, An engineer wants to get an unauthorized response from the request to verify they are unable to access the resource. This demonstrates that the infastructure is deployed correctly for the application, the application is successfully deployed to the infrastructure, and that authentication is working correctly.
+
+An engineer, who is creating a template, should want to create integration tests that test the deployed infastructure functionality and/or the application deployed. There are two use cases we see this being the case:
+  1. Application Infastructure prociding Authentication for a deployed application
+  2. A deployed application with authentication.
+
+These tests are provided after the infastructure has been deployed and before releasing code into a new environment. 
+
+The user will make use of the HTTP_GET function that utilizes the existing AUTHORIZOR function to obtain a bearer token.
 
 # Background Information
+<!--
+Tech used
+How do these tech work?
+Reference links to these tech
+Reference diagrams for tech 
+-->
+To allow integration tests to authenticate to an application, the OAuth 2.0 Client Credentials Grant Flow is used. This permits a confidential client to use its own credentials instead of impersonating a user, to authenticate when calling another service, web or otherwise.
+
+![image](https://user-images.githubusercontent.com/17349002/61244953-64e10400-a719-11e9-90ce-82d88e29ab81.png)
 
 # Out-of-Scope
+<!-- 
+When and why would a user not use this?
+What are related items that will not be addressed?
+-->
 
-# Diagram
+  1. POST, DELETE, and other types or requests besided GET are out of scope.
+  2. Synthetic tests are out of scope.
+
+# Swimlane Diagram
+<!-- 
+What is the right diagram?
+	Sequence Diagram - When you want to show data/information flow.
+	Comonent Diagram - When you want to show how components of a system interact.
+	Swimlane Diagram - When you want to show information/data flow between domains and or comonents.
+	UML Diagram      - When you want to show how OO class/interface design.
+-->
 ![image](https://user-images.githubusercontent.com/17349002/61076671-c7b95f00-a3ea-11e9-8361-205ed088d0f6.png)
 
 # Inputs
+<!-- 
+What are the inputs?
+What are the input types?
+What are the input descriptions?
+How are the inputs provided?
+-->
 
-SP ID
-SP Secret
-tenant id
-url to test
-multi-tenant
+All inputs are provied to the functions used by the testing framework by the user. The Service Principle Secret should be stored in Key Vault and access at the time of the function call so that it's not stored in memory anylonger than needed.
+
+| Name | Type | Description |
+|------|------|-------------|
+| Serivce Principle ID | string | Service Principle ID with Access to Application |
+| Serivce Principle Secret | string | Service Principle Secret |
+| tenant id | string | ID of the tenant where the Serivce Principle resides |
+| url to test | string | HTTP URL of the service to be tested |
 
 # Outputs
+<!-- 
+What does this return to the program or user? 
+How are the outputs surfaced?
+-->
+
+The function should output the resonse and response code to the calling function.
+
+| Name | Type | Description |
+|------|------|-------------|
+| Response Body | JSON, String, Binary, etc | The body of the resonse returned by the service |
+| Status Code | integer | The response status code. Examples: 200 401 500 |

--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -1,29 +1,19 @@
 # Purpose/Description
-<!-- 
-Who is the user?
-What does it do?
-When does a users use this?
-Why does a user want this?
-How does a user use this?
--->
 
-An engineer wants to get a successful resonse back from an appication using Azure AD based Authentication deployed to Cobalt managed infastrcuture. And/or, An engineer wants to get an unauthorized response from the request to verify they are unable to access the resource. This demonstrates that the infastructure is deployed correctly for the application, the application is successfully deployed to the infrastructure, and that authentication is working correctly.
+For this design, an engineer building a template would like the ability to test a deployed application with Authentication. Currently the Cobalt test-harness cannot and the http calls to an authenticated service will return a 401 unauthorized. This is help in its self because it does show that authentication has been configured. However, we would like the ability to also test for a 200 Successful status code. This will give the ability for the CI/CD pipeline to test for both negative and positive results during a deployment.
 
-An engineer, who is creating a template, should want to create integration tests that test the deployed infastructure functionality and/or the application deployed. There are two use cases we see this being the case:
-  1. Application Infastructure prociding Authentication for a deployed application
+There are two use cases we see an engineer would like to test:
+  1. Application Infrastructure providing authentication for a deployed application
   2. A deployed application with authentication.
 
-These tests are provided after the infastructure has been deployed and before releasing code into a new environment. 
+The infrastructure should be deployed by the CI/CD pipeline, either local or cloud based. Once the infrastructure is deployed the integration test should be run against that infrastructure. The echo server image should be deployed to the app service behind EasyAuth using AAD as the provider. Testing for both a 401 and 200 status codes will allow us to understand that the infrastructure is deployed correctly.
 
-The user will make use of the HTTP_GET function that utilizes the existing AUTHORIZOR function to obtain a bearer token.
+Also, after deploying the application containers to the infrastructure, a 401 and 200 status code will similarly allow us to test if the application has been deployed successfully to the environment. These test should be run in each environment i.e. Dev-Int, Stage, QA, Production, etc...
+
+The user will make use of the HTTP_GET function that utilizes the existing AUTHORIZER function to obtain a bearer token.
 
 # Background Information
-<!--
-Tech used
-How do these tech work?
-Reference links to these tech
-Reference diagrams for tech 
--->
+
 To allow integration tests to authenticate to an application, the OAuth 2.0 Client Credentials Grant Flow is used. This permits a confidential client to use its own credentials instead of impersonating a user, to authenticate when calling another service, web or otherwise.
 
 ![image](https://user-images.githubusercontent.com/17349002/61244953-64e10400-a719-11e9-90ce-82d88e29ab81.png)
@@ -31,50 +21,30 @@ To allow integration tests to authenticate to an application, the OAuth 2.0 Clie
 ref: [Service to service calls using client credentials](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-client-creds-grant-flow)
 
 # Out-of-Scope
-<!-- 
-When and why would a user not use this?
-What are related items that will not be addressed?
--->
 
-  1. POST, DELETE, and other types or requests besided GET are out of scope.
+  1. POST, DELETE, and other types or requests besides GET are out of scope.
   2. Synthetic tests are out of scope.
 
-# Swimlane Diagram
-<!-- 
-What is the right diagram?
-	Sequence Diagram - When you want to show data/information flow.
-	Comonent Diagram - When you want to show how components of a system interact.
-	Swimlane Diagram - When you want to show information/data flow between domains and or comonents.
-	UML Diagram      - When you want to show how OO class/interface design.
--->
+# Swim lane Diagram
+
 ![image](https://user-images.githubusercontent.com/17349002/61076671-c7b95f00-a3ea-11e9-8361-205ed088d0f6.png)
 
 # Inputs
-<!-- 
-What are the inputs?
-What are the input types?
-What are the input descriptions?
-How are the inputs provided?
--->
 
-All inputs are provied to the functions used by the testing framework by the user. The Service Principle Secret should be stored in Key Vault and access at the time of the function call so that it's not stored in memory anylonger than needed.
+All inputs are provided to the functions used by the testing framework by the user. The Service Principle Secret should be stored in Key Vault and access at the time of the function call so that it's not stored in memory any longer than needed.
 
 | Name | Type | Description |
 |------|------|-------------|
-| Serivce Principle ID | string | Service Principle ID with Access to Application |
-| Serivce Principle Secret | string | Service Principle Secret |
-| tenant id | string | ID of the tenant where the Serivce Principle resides |
+| Service Principle ID | string | Service Principle ID with Access to Application |
+| Service Principle Secret | string | Service Principle Secret |
+| tenant id | string | ID of the tenant where the Service Principle resides |
 | url to test | string | HTTP URL of the service to be tested |
 
 # Outputs
-<!-- 
-What does this return to the program or user? 
-How are the outputs surfaced?
--->
 
-The function should output the resonse and response code to the calling function.
+The function should output the response and response code to the calling function.
 
 | Name | Type | Description |
 |------|------|-------------|
-| Response Body | JSON, String, Binary, etc | The body of the resonse returned by the service |
+| Response Body | JSON, String, Binary, etc | The body of the response returned by the service |
 | Status Code | integer | The response status code. Examples: 200 401 500 |

--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -28,6 +28,8 @@ To allow integration tests to authenticate to an application, the OAuth 2.0 Clie
 
 ![image](https://user-images.githubusercontent.com/17349002/61244953-64e10400-a719-11e9-90ce-82d88e29ab81.png)
 
+ref: [Service to service calls using client credentials](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-client-creds-grant-flow)
+
 # Out-of-Scope
 <!-- 
 When and why would a user not use this?

--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -6,7 +6,7 @@ There are two use cases we see an engineer would like to test:
   1. Application Infrastructure deployment with  authentication enabled.
   2. A deployed application with authentication enabled.
 
-The infrastructure should be deployed by the CI/CD pipeline, either local or cloud based. Once the infrastructure is deployed the integration test should be run against that infrastructure. The echo server image should be deployed to the app service behind EasyAuth using AAD as the provider. Testing for both a 401 and 200 status codes will allow us to understand that the infrastructure is deployed correctly.
+The infrastructure should be deployed by the CI/CD pipeline, either local or cloud based. Once the infrastructure is deployed the integration test should be run against that infrastructure. The [echo server](https://hub.docker.com/r/msftcse/cobalt-azure-simple) image should be deployed to the app service behind EasyAuth using AAD as the provider. Testing for both a 401 and 200 status codes will allow us to understand that the infrastructure is deployed correctly.
 
 Also, after deploying the application containers to the infrastructure, a 401 and 200 status code will similarly allow us to test that the application has been deployed successfully to the environment. These tests should be run in each environment i.e. Dev-Int, Stage, QA, Production, etc...
 
@@ -14,9 +14,31 @@ The user will make use of the HTTP_GET function that utilizes the existing AUTHO
 
 # Background Information
 
+Using the credentials grant flow allows a client to using it's own Service Principle and Secret as a username/password to authenticate to the service that it's calling.
+
 To allow integration tests to authenticate to an application, the OAuth 2.0 Client Credentials Grant Flow is used. This permits a confidential client to use its own credentials instead of impersonating a user, to authenticate when calling another service, web or otherwise.
 
 ![image](https://user-images.githubusercontent.com/17349002/61244953-64e10400-a719-11e9-90ce-82d88e29ab81.png)
+
+## Example Request
+```
+POST /contoso.com/oauth2/token HTTP/1.1
+Host: login.microsoftonline.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&client_id=625bc9f6-3bf6-4b6d-94ba-e97cf07a22de&client_secret=qkDwDJlDfig2IpeuUZYKH1Wb8q1V0ju6sILxQQqhJ+s=&resource=https%3A%2F%2Fservice.contoso.com%2F
+```
+
+## Example Response
+```
+{
+"access_token":"eyJhbGciOiJSUzI1NiIsIng1dCI6IjdkRC1nZWNOZ1gxWmY3R0xrT3ZwT0IyZGNWQSIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL3NlcnZpY2UuY29udG9zby5jb20vIiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvN2ZlODE0NDctZGE1Ny00Mzg1LWJlY2ItNmRlNTdmMjE0NzdlLyIsImlhdCI6MTM4ODQ0ODI2NywibmJmIjoxMzg4NDQ4MjY3LCJleHAiOjEzODg0NTIxNjcsInZlciI6IjEuMCIsInRpZCI6IjdmZTgxNDQ3LWRhNTctNDM4NS1iZWNiLTZkZTU3ZjIxNDc3ZSIsIm9pZCI6ImE5OTE5MTYyLTkyMTctNDlkYS1hZTIyLWYxMTM3YzI1Y2RlYSIsInN1YiI6ImE5OTE5MTYyLTkyMTctNDlkYS1hZTIyLWYxMTM3YzI1Y2RlYSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzdmZTgxNDQ3LWRhNTctNDM4NS1iZWNiLTZkZTU3ZjIxNDc3ZS8iLCJhcHBpZCI6ImQxN2QxNWJjLWM1NzYtNDFlNS05MjdmLWRiNWYzMGRkNThmMSIsImFwcGlkYWNyIjoiMSJ9.aqtfJ7G37CpKV901Vm9sGiQhde0WMg6luYJR4wuNR2ffaQsVPPpKirM5rbc6o5CmW1OtmaAIdwDcL6i9ZT9ooIIicSRrjCYMYWHX08ip-tj-uWUihGztI02xKdWiycItpWiHxapQm0a8Ti1CWRjJghORC1B1-fah_yWx6Cjuf4QE8xJcu-ZHX0pVZNPX22PHYV5Km-vPTq2HtIqdboKyZy3Y4y3geOrRIFElZYoqjqSv5q9Jgtj5ERsNQIjefpyxW3EwPtFqMcDm4ebiAEpoEWRN4QYOMxnC9OUBeG9oLA0lTfmhgHLAtvJogJcYFzwngTsVo6HznsvPWy7UP3MINA",
+"token_type":"Bearer",
+"expires_in":"3599",
+"expires_on":"1388452167",
+"resource":"https://service.contoso.com/"
+}
+```
 
 ref: [Service to service calls using client credentials](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-client-creds-grant-flow)
 
@@ -54,7 +76,7 @@ ref: [authorizer.go: Lines 19 - 32](https://github.com/microsoft/cobalt/blob/35e
 
 # Inputs
 
-All inputs are provided to the functions used by the testing framework by the user. The Service Principle Secret should be stored in Key Vault and accessed only at the time of the function call so that it's not stored in memory any longer than needed.
+All inputs are provided to the functions used by the [testing framework integrated into Cobalt](https://github.com/microsoft/cobalt/blob/master/test-harness/README.md) by the user. The Service Principle Secret should be stored in Key Vault and accessed only at the time of the function call so that it's not stored in memory any longer than needed.
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -1,14 +1,14 @@
 # Purpose/Description
 
-For this design, an engineer building a template would like the ability to test a deployed application with Authentication. Currently the Cobalt test-harness cannot and the http calls to an authenticated service will return a 401 unauthorized. This is help in its self because it does show that authentication has been configured. However, we would like the ability to also test for a 200 Successful status code. This will give the ability for the CI/CD pipeline to test for both negative and positive results during a deployment.
+For this design, an engineer building a template would like the ability to test a deployed application with authentication enabled. Currently the Cobalt test-harness cannot successfully complete http calls to an authenticated service and they will return a 401 unauthorized in the response. This is helpful in its self, because it does show that authentication has been configured. However, we would like the ability to also test for a 200 Successful status code. This will give the ability for the CI/CD pipeline to test for both negative and positive results during a deployment.
 
 There are two use cases we see an engineer would like to test:
-  1. Application Infrastructure providing authentication for a deployed application
-  2. A deployed application with authentication.
+  1. Application Infrastructure deployment with  authentication enabled.
+  2. A deployed application with authentication enabled.
 
 The infrastructure should be deployed by the CI/CD pipeline, either local or cloud based. Once the infrastructure is deployed the integration test should be run against that infrastructure. The echo server image should be deployed to the app service behind EasyAuth using AAD as the provider. Testing for both a 401 and 200 status codes will allow us to understand that the infrastructure is deployed correctly.
 
-Also, after deploying the application containers to the infrastructure, a 401 and 200 status code will similarly allow us to test if the application has been deployed successfully to the environment. These test should be run in each environment i.e. Dev-Int, Stage, QA, Production, etc...
+Also, after deploying the application containers to the infrastructure, a 401 and 200 status code will similarly allow us to test that the application has been deployed successfully to the environment. These tests should be run in each environment i.e. Dev-Int, Stage, QA, Production, etc...
 
 The user will make use of the HTTP_GET function that utilizes the existing AUTHORIZER function to obtain a bearer token.
 
@@ -31,7 +31,7 @@ ref: [Service to service calls using client credentials](https://docs.microsoft.
 
 # Inputs
 
-All inputs are provided to the functions used by the testing framework by the user. The Service Principle Secret should be stored in Key Vault and access at the time of the function call so that it's not stored in memory any longer than needed.
+All inputs are provided to the functions used by the testing framework by the user. The Service Principle Secret should be stored in Key Vault and accessed only at the time of the function call so that it's not stored in memory any longer than needed.
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/design-reference/architecture/authn/providers/azuread/integration_test.md
+++ b/design-reference/architecture/authn/providers/azuread/integration_test.md
@@ -2,13 +2,12 @@
 
 Users that would like to create integration tests and have an application they would like to verify is deployed but uses Authentication provide by Azure AD, they should have the ability to generate a token in the tests and use it in making the request to the application.
 
-
-
 # Background Information
 
 # Out-of-Scope
 
 # Diagram
+![image](https://user-images.githubusercontent.com/17349002/61076671-c7b95f00-a3ea-11e9-8361-205ed088d0f6.png)
 
 # Inputs
 


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [x] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, integration tests are not able to authenticate to Apps secured using Azure AD.

Issue Number: #197 


## What is the new behavior?
-------------------------------------
<!-- Please describe the behavior or changes that are being added by this PR. -->

This adds the proposed design to allow integration tests to make authenticated requests using Azure AD.
-
-
-

## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
n/a

## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
n/a