### PR TITLE
Moving to new ASE that can be deployed in another subscription

### DIFF
--- a/devops/providers/azure-devops/templates/azure-pipelines.yml
+++ b/devops/providers/azure-devops/templates/azure-pipelines.yml
@@ -51,3 +51,4 @@ stages:
     - jobName: az_isolated_service_single_region
       terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
       terraformWorkspacePrefix: 'iso'
+      deploymentTimeoutInMinutes: 120

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
@@ -21,6 +21,10 @@ jobs:
   - deployment: Provision_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
     condition: eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
+
+    ${{ if config.deploymentTimeoutInMinutes }}:
+      timeoutInMinutes: '${{ config.deploymentTimeoutInMinutes }}'
+
     pool:
       vmImage: $(AGENT_POOL)
 

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipelines.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipelines.yml
@@ -32,3 +32,4 @@ stages:
     configurationMatrix:
     - jobName: template_deployment
       terraformTemplatePath: '$(TF_DEPLOYMENT_TEMPLATE_ROOT)'
+      deploymentTimeoutInMinutes: 120

--- a/infra/templates/az-isolated-service-single-region/commons.tf
+++ b/infra/templates/az-isolated-service-single-region/commons.tf
@@ -6,12 +6,12 @@ data "azurerm_subscription" "current" {}
 
 locals {
   prefix        = "${lower(var.name)}-${lower(terraform.workspace)}"
-  admin_rg_name = "${local.prefix}-admin-rg"                  // name of resource group used for admin resources
-  app_rg_name   = "${local.prefix}-app-rg"                    // name of app resource group
-  sp_name       = "${local.prefix}-sp"                        // name of service plan
-  ai_name       = "${local.prefix}-ai"                        // name of app insights
-  kv_name       = format("%.20s-kv", local.prefix)            // name of key vault
-  acr_name      = replace("${local.prefix}azcr", "/\\W/", "") // name of acr
+  admin_rg_name = "${local.prefix}-admin-rg" // name of resource group used for admin resources
+  app_rg_name   = "${local.prefix}-app-rg"   // name of app resource group
+  sp_name       = "${local.prefix}-sp"       // name of service plan
+  ai_name       = "${local.prefix}-ai"       // name of app insights
+  kv_name       = format("%s%s-kv", format("%.10s", lower(var.name)), format("%.10s", lower(terraform.workspace)))
+  acr_name      = replace(format("%s%sacr", format("%.10s", lower(var.name)), format("%.10s", lower(terraform.workspace))), "/\\W/", "")
   ase_sub_id    = var.ase_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.ase_subscription_id
   app_sub_id    = var.app_dev_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.app_dev_subscription_id
 

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -24,8 +24,8 @@ deployment_targets = [
   }
 ]
 
-ase_name                = "cobalt-static-ase"
+ase_name                = "co-static-ase"
 name                    = "isolated-service"
-ase_resource_group      = "cobalt-static-ase-rg"
-ase_vnet_name           = "cobalt-static-ase-vnet"
+ase_resource_group      = "co-static-ase-rg"
+ase_vnet_name           = "co-static-ase-vnet"
 resource_group_location = "eastus2"

--- a/infra/templates/az-isolated-service-single-region/tests/integration/integration_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/integration_test.go
@@ -10,9 +10,9 @@ import (
 
 var region = "eastus2"
 var workspace = ""
-var aseName = "cobalt-static-ase"
-var aseVnetName = "cobalt-static-ase-vnet"
-var aseResourceGroup = "cobalt-static-ase-rg"
+var aseName = "co-static-ase"
+var aseVnetName = "co-static-ase-vnet"
+var aseResourceGroup = "co-static-ase-rg"
 var adminSubscription = os.Getenv("ARM_SUBSCRIPTION_ID")
 
 var deploymentTargets = []map[string]string{

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -18,8 +17,8 @@ var region = "eastus2"
 var workspace = "az-isolated-" + strings.ToLower(random.UniqueId())
 
 var adminSubscription = os.Getenv("ARM_SUBSCRIPTION_ID")
-var aseName = "cobalt-static-ase"
-var aseResourceGroup = "cobalt-static-ase-rg"
+var aseName = "co-static-ase"
+var aseResourceGroup = "co-static-ase-rg"
 
 var tfOptions = &terraform.Options{
 	TerraformDir: "../../",
@@ -80,10 +79,9 @@ func TestTemplate(t *testing.T) {
 			"default_action": "Deny"
 		}]
 	}`)
-	acrNameRegex := regexp.MustCompile("\\W")
 	expectedAzureContainerRegistry := asMap(t, `{
 		"admin_enabled":       true,
-		"name":                "`+acrNameRegex.ReplaceAllString("isolated-service-"+workspace+"-azcr", "")+`",
+		"name":                "isolatedsazisolateacr",
 		"resource_group_name": "isolated-service-`+workspace+`-app-rg",
 		"sku":                 "Premium"
 	}`)


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [N/A] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
Current pipeline does not target the CSE White subscription. 

Issue Number: https://github.com/microsoft/cobalt/issues/231


## What is the new behavior?
-------------------------------------
Deployment should target the new CSE White subscription. In order to do this we need to create a static ASE environment in the new subscription, but this cannot have the same name as the one in the old subscription because it is a global name.

Changes are:

* Moving to new ASE that can be deployed in another subscription
    
* Refactor deployment template to consume an optional deployment timeout
      configuration

* Refactor keyvault name to prevent abundance of naming clashes that are
      seen with this resource

## Does this introduce a breaking change?
-------------------------------------
- [NO]
