### PR TITLE
Add IP Whitelist for KeyVault and ACR

### DIFF
--- a/devops/providers/azure-devops/templates/infrastructure/scripts/test-integration.sh
+++ b/devops/providers/azure-devops/templates/infrastructure/scripts/test-integration.sh
@@ -14,4 +14,4 @@ cd "$ARTIFACT_ROOT"/"$TERRAFORM_TEMPLATE_PATH"
 # Setting the scripts to be run as executable
 chmod -fR 755 *.sh || true
 
-go test $(go list ./... | grep "$TERRAFORM_TEMPLATE_PATH" | grep "integration")
+go test -v $(go list ./... | grep "$TERRAFORM_TEMPLATE_PATH" | grep "integration")

--- a/devops/providers/azure-devops/templates/infrastructure/scripts/test-unit.sh
+++ b/devops/providers/azure-devops/templates/infrastructure/scripts/test-unit.sh
@@ -14,4 +14,4 @@ cd "$ARTIFACT_ROOT"/"$TERRAFORM_TEMPLATE_PATH"
 # Setting the scripts to be run as executable
 chmod -fR 755 *.sh || true
 
-go test $(go list ./... | grep "$TERRAFORM_TEMPLATE_PATH" | grep "unit")
+go test -v $(go list ./... | grep "$TERRAFORM_TEMPLATE_PATH" | grep "unit")

--- a/infra/modules/providers/azure/container-registry/main.tf
+++ b/infra/modules/providers/azure/container-registry/main.tf
@@ -9,5 +9,36 @@ resource "azurerm_container_registry" "container_registry" {
   sku                 = var.container_registry_sku
   admin_enabled       = var.container_registry_admin_enabled
   tags                = var.container_registry_tags
+
+  # This dynamic block configures a default DENY action to all incoming traffic
+  # in the case that one of the following hold true:
+  #   1: IP whitelist has been configured
+  #   2: Subnet whitelist has been configured
+  dynamic "network_rule_set" {
+    for_each = length(concat(var.resource_ip_whitelist, var.subnet_id_whitelist)) == 0 ? [] : [var.resource_ip_whitelist]
+    content {
+      default_action = "Deny"
+      # This dynamic block configures "Allow" action to all of the whitelisted IPs. It is only
+      # stamped out in the case that there are IPs configured for whitelist
+      dynamic "ip_rule" {
+        for_each = var.resource_ip_whitelist
+        content {
+          action   = "Allow"
+          ip_range = ip_rule.value
+        }
+      }
+    }
+  }
 }
 
+# Configures access from the subnets that should have access
+resource "null_resource" "acr_acr_subnet_access_rule" {
+  count = length(var.subnet_id_whitelist)
+  triggers = {
+    acr_id  = azurerm_container_registry.container_registry.id
+    subnets = join(",", var.subnet_id_whitelist)
+  }
+  provisioner "local-exec" {
+    command = "az acr network-rule add --name ${var.container_registry_name} --subnet ${var.subnet_id_whitelist[count.index]}"
+  }
+}

--- a/infra/modules/providers/azure/container-registry/variables.tf
+++ b/infra/modules/providers/azure/container-registry/variables.tf
@@ -25,3 +25,13 @@ variable "container_registry_tags" {
   default     = {}
 }
 
+variable "subnet_id_whitelist" {
+  description = "If supplied this represents the subnet IDs that should be allowed to access this resource"
+  type        = list(string)
+  default     = []
+}
+variable "resource_ip_whitelist" {
+  description = "A list of IPs and/or IP ranges that should have access to the provisioned container registry"
+  type        = list(string)
+  default     = []
+}

--- a/infra/modules/providers/azure/keyvault/main.tf
+++ b/infra/modules/providers/azure/keyvault/main.tf
@@ -27,11 +27,13 @@ resource "azurerm_key_vault" "keyvault" {
 
   # This block configures VNET integration if a subnet whitelist is specified
   dynamic "network_acls" {
-    for_each = length(var.subnet_id_whitelist) == 0 ? [] : [var.subnet_id_whitelist]
+    # this block allows the loop to run 1 or 0 times based on if the resource ip whitelist or subnet id whitelist is provided.
+    for_each = length(concat(var.resource_ip_whitelist, var.subnet_id_whitelist)) == 0 ? [] : [""]
     content {
       bypass                     = "None"
       default_action             = "Deny"
-      virtual_network_subnet_ids = network_acls.value
+      virtual_network_subnet_ids = var.subnet_id_whitelist
+      ip_rules                   = var.resource_ip_whitelist
     }
   }
 

--- a/infra/modules/providers/azure/keyvault/variables.tf
+++ b/infra/modules/providers/azure/keyvault/variables.tf
@@ -45,4 +45,8 @@ variable "subnet_id_whitelist" {
   default     = []
 }
 
-
+variable "resource_ip_whitelist" {
+  description = "A list of IPs and/or IP ranges that should have access to the provisioned keyvault"
+  type        = list(string)
+  default     = []
+}

--- a/infra/modules/providers/azure/provider/main.tf
+++ b/infra/modules/providers/azure/provider/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~>1.31.0"
+  version = "~>1.32.0"
 }
 
 provider "null" {

--- a/infra/templates/az-isolated-service-single-region/app.tf
+++ b/infra/templates/az-isolated-service-single-region/app.tf
@@ -36,10 +36,11 @@ data "external" "ase_subnets" {
 }
 
 module "keyvault" {
-  source              = "../../modules/providers/azure/keyvault"
-  keyvault_name       = local.kv_name
-  resource_group_name = azurerm_resource_group.app_rg.name
-  subnet_id_whitelist = values(data.external.ase_subnets.result)
+  source                = "../../modules/providers/azure/keyvault"
+  keyvault_name         = local.kv_name
+  resource_group_name   = azurerm_resource_group.app_rg.name
+  subnet_id_whitelist   = values(data.external.ase_subnets.result)
+  resource_ip_whitelist = var.resource_ip_whitelist
   providers = {
     "azurerm" = "azurerm.app_dev"
   }
@@ -53,33 +54,9 @@ module "container_registry" {
   container_registry_admin_enabled = true
   // Note: only premium ACRs allow configuration of network access restrictions
   container_registry_sku = "Premium"
+  subnet_id_whitelist    = values(data.external.ase_subnets.result)
+  resource_ip_whitelist  = var.resource_ip_whitelist
   providers = {
     "azurerm" = "azurerm.app_dev"
-  }
-}
-
-# Configures the default rule to be "Deny All Traffic"
-resource "null_resource" "acr_default_deny_network_rule" {
-  triggers = {
-    acr_id = module.container_registry.container_registry_id
-  }
-
-  provisioner "local-exec" {
-    command = "az acr update --name ${module.container_registry.container_registry_name} --default-action Deny"
-  }
-}
-
-# Configures access from the subnets that should have access
-resource "null_resource" "acr_acr_subnet_access_rule" {
-  count      = length(values(data.external.ase_subnets.result))
-  depends_on = ["null_resource.acr_default_deny_network_rule"]
-
-  triggers = {
-    acr_id  = module.container_registry.container_registry_id
-    subnets = join(",", values(data.external.ase_subnets.result))
-  }
-
-  provisioner "local-exec" {
-    command = "az acr network-rule add --name ${module.container_registry.container_registry_name} --subnet ${values(data.external.ase_subnets.result)[count.index]}"
   }
 }

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -26,7 +26,6 @@ deployment_targets = [
 
 # Note: this is configured as such only to test IP Whitelists. This is a well
 # known DNS address
-#   https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
 resource_ip_whitelist   = ["1.1.1.1"]
 ase_name                = "cobalt-static-ase"
 name                    = "isolated-service"

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -24,6 +24,7 @@ deployment_targets = [
   }
 ]
 
+resource_ip_whitelist   = ["127.0.0.1"] # Note: this is configured as such only to test IP Whitelists
 ase_name                = "cobalt-static-ase"
 name                    = "isolated-service"
 ase_resource_group      = "cobalt-static-ase-rg"

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -27,7 +27,7 @@ deployment_targets = [
 # Note: this is configured as such only to test IP Whitelists. This is the IP of a local
 # branch office and should be changed by all customers using this template.
 #   https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
-resource_ip_whitelist   = ["63.65.120.22"]
+resource_ip_whitelist   = ["1.1.1.1"]
 ase_name                = "cobalt-static-ase"
 name                    = "isolated-service"
 ase_resource_group      = "cobalt-static-ase-rg"

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -24,7 +24,10 @@ deployment_targets = [
   }
 ]
 
-resource_ip_whitelist   = ["127.0.0.1"] # Note: this is configured as such only to test IP Whitelists
+# Note: this is configured as such only to test IP Whitelists. This is the IP of a local
+# branch office and should be changed by all customers using this template.
+#   https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+resource_ip_whitelist   = ["63.65.120.22"]
 ase_name                = "cobalt-static-ase"
 name                    = "isolated-service"
 ase_resource_group      = "cobalt-static-ase-rg"

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -24,8 +24,8 @@ deployment_targets = [
   }
 ]
 
-# Note: this is configured as such only to test IP Whitelists. This is the IP of a local
-# branch office and should be changed by all customers using this template.
+# Note: this is configured as such only to test IP Whitelists. This is a well
+# known DNS address
 #   https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
 resource_ip_whitelist   = ["1.1.1.1"]
 ase_name                = "cobalt-static-ase"

--- a/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
@@ -23,7 +23,7 @@ func verifyVnetIntegrationForACR(goTest *testing.T, output infratests.TerraformO
 func verifyIPWhitelistForACR(goTest *testing.T, acrACLs *containerregistry.NetworkRuleSet) {
 	// Refer to the documentation in `terraform.tfvars` to understand why this IP address
 	// is whitelisted
-	expectedIpsWithACRAccess := []string{ "1.1.1.1" }
+	expectedIpsWithACRAccess := []string{"1.1.1.1"}
 	ipsWithACRAccess := make([]string, len(*acrACLs.IPRules))
 	for i, rule := range *acrACLs.IPRules {
 		ipsWithACRAccess[i] = *rule.IPAddressOrRange

--- a/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
@@ -23,7 +23,7 @@ func verifyVnetIntegrationForACR(goTest *testing.T, output infratests.TerraformO
 func verifyIPWhitelistForACR(goTest *testing.T, acrACLs *containerregistry.NetworkRuleSet) {
 	// Refer to the documentation in `terraform.tfvars` to understand why this IP address
 	// is whitelisted
-	expectedIpsWithACRAccess := []string{ "63.65.120.22" }
+	expectedIpsWithACRAccess := []string{ "1.1.1.1" }
 	ipsWithACRAccess := make([]string, len(*acrACLs.IPRules))
 	for i, rule := range *acrACLs.IPRules {
 		ipsWithACRAccess[i] = *rule.IPAddressOrRange

--- a/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
@@ -16,13 +16,23 @@ func verifyVnetIntegrationForACR(goTest *testing.T, output infratests.TerraformO
 	acrName := output["acr_name"].(string)
 	acrACLs := azure.ACRNetworkAcls(goTest, adminSubscription, appDevResourceGroup, acrName)
 	verifyVnetSubnetWhitelistForACR(goTest, acrACLs)
-	verifyIpWhitelistForACR(goTest, acrACLs)
+	verifyIPWhitelistForACR(goTest, acrACLs)
 }
 
-func verifyIpWhitelistForACR(goTest *testing.T, acrACLs *containerregistry.NetworkRuleSet) {
-	fmt.Println("TODO: validate ip whitelist")
+// Verify that only the correct IPs have access to the ACR
+func verifyIPWhitelistForACR(goTest *testing.T, acrACLs *containerregistry.NetworkRuleSet) {
+	// Refer to the documentation in `terraform.tfvars` to understand why this IP address
+	// is whitelisted
+	expectedIpsWithACRAccess := []string{ "63.65.120.22" }
+	ipsWithACRAccess := make([]string, len(*acrACLs.IPRules))
+	for i, rule := range *acrACLs.IPRules {
+		ipsWithACRAccess[i] = *rule.IPAddressOrRange
+	}
+
+	requireEqualIgnoringOrderAndCase(goTest, ipsWithACRAccess, expectedIpsWithACRAccess)
 }
 
+// Verify that only the correct subnets have access to the ACR
 func verifyVnetSubnetWhitelistForACR(goTest *testing.T, acrACLs *containerregistry.NetworkRuleSet) {
 	subnetIDs := azure.VnetSubnetsList(goTest, adminSubscription, aseResourceGroup, aseVnetName)
 

--- a/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/acr.go
@@ -15,6 +15,15 @@ func verifyVnetIntegrationForACR(goTest *testing.T, output infratests.TerraformO
 	appDevResourceGroup := output["app_dev_resource_group"].(string)
 	acrName := output["acr_name"].(string)
 	acrACLs := azure.ACRNetworkAcls(goTest, adminSubscription, appDevResourceGroup, acrName)
+	verifyVnetSubnetWhitelistForACR(goTest, acrACLs)
+	verifyIpWhitelistForACR(goTest, acrACLs)
+}
+
+func verifyIpWhitelistForACR(goTest *testing.T, acrACLs *containerregistry.NetworkRuleSet) {
+	fmt.Println("TODO: validate ip whitelist")
+}
+
+func verifyVnetSubnetWhitelistForACR(goTest *testing.T, acrACLs *containerregistry.NetworkRuleSet) {
 	subnetIDs := azure.VnetSubnetsList(goTest, adminSubscription, aseResourceGroup, aseVnetName)
 
 	// The default action should be to deny all traffic

--- a/infra/templates/az-isolated-service-single-region/tests/integration/keyvault.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/keyvault.go
@@ -2,11 +2,12 @@ package integration
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/microsoft/cobalt/test-harness/infratests"
 	"github.com/microsoft/cobalt/test-harness/terratest-extensions/modules/azure"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // Verifies that the Key Vault instance deployed is properly isolated within the VNET
@@ -14,8 +15,27 @@ func verifyVnetIntegrationForKeyVault(goTest *testing.T, output infratests.Terra
 	appDevResourceGroup := output["app_dev_resource_group"].(string)
 	vaultName := output["keyvault_name"].(string)
 	keyVaultACLs := azure.KeyVaultNetworkAcls(goTest, adminSubscription, appDevResourceGroup, vaultName)
-	subnetIDs := azure.VnetSubnetsList(goTest, adminSubscription, aseResourceGroup, aseVnetName)
+	verifyVnetSubnetWhitelistForKeyvault(goTest, keyVaultACLs)
+	verifyIPWhitelistForKeyvault(goTest, keyVaultACLs)
+}
 
+// Verify that only the correct IPs have access to the Keyvault
+func verifyIPWhitelistForKeyvault(goTest *testing.T, keyVaultACLs *keyvault.NetworkRuleSet) {
+	// Refer to the documentation in `terraform.tfvars` to understand why this IP address
+	// is whitelisted
+	// Terraform seems to be adding a CIDR block with the IPs provided, for example the expected IP below of 1.1.1.1 would be 1.1.1.1/32 in the CIDR format.
+	expectedIpsWithKeyvaultAccess := []string{"1.1.1.1"}
+	ipsWithKeyvaultAccess := make([]string, len(*keyVaultACLs.IPRules))
+	for i, rule := range *keyVaultACLs.IPRules {
+		ipsWithKeyvaultAccess[i] = *rule.Value
+	}
+
+	requireEqualIgnoringOrderAndCase(goTest, ipsWithKeyvaultAccess, expectedIpsWithKeyvaultAccess)
+}
+
+// Verify that only the correct subnets have access to the ACR
+func verifyVnetSubnetWhitelistForKeyvault(goTest *testing.T, keyVaultACLs *keyvault.NetworkRuleSet) {
+	subnetIDs := azure.VnetSubnetsList(goTest, adminSubscription, aseResourceGroup, aseVnetName)
 	// No azure services should have bypass rules that allow them to circumvent the VNET isolation
 	require.Equal(
 		goTest,

--- a/infra/templates/az-isolated-service-single-region/tests/integration/keyvault.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/keyvault.go
@@ -24,7 +24,7 @@ func verifyIPWhitelistForKeyvault(goTest *testing.T, keyVaultACLs *keyvault.Netw
 	// Refer to the documentation in `terraform.tfvars` to understand why this IP address
 	// is whitelisted
 	// Terraform seems to be adding a CIDR block with the IPs provided, for example the expected IP below of 1.1.1.1 would be 1.1.1.1/32 in the CIDR format.
-	expectedIpsWithKeyvaultAccess := []string{"1.1.1.1"}
+	expectedIpsWithKeyvaultAccess := []string{"1.1.1.1/32"}
 	ipsWithKeyvaultAccess := make([]string, len(*keyVaultACLs.IPRules))
 	for i, rule := range *keyVaultACLs.IPRules {
 		ipsWithKeyvaultAccess[i] = *rule.Value

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -78,7 +78,7 @@ func TestTemplate(t *testing.T) {
 		"network_acls": [{
 			"bypass":         "None",
 			"default_action": "Deny",
-			"ip_rules": ["1.1.1.1"]
+			"ip_rules": ["1.1.1.1/32"]
 		}]
 	}`)
 	acrNameRegex := regexp.MustCompile("\\W")

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -77,7 +77,8 @@ func TestTemplate(t *testing.T) {
 	expectedKeyVault := asMap(t, `{
 		"network_acls": [{
 			"bypass":         "None",
-			"default_action": "Deny"
+			"default_action": "Deny",
+			"ip_rules": ["1.1.1.1"]
 		}]
 	}`)
 	acrNameRegex := regexp.MustCompile("\\W")
@@ -90,7 +91,7 @@ func TestTemplate(t *testing.T) {
 			"default_action": "Deny",
 			"ip_rule": [{
 				"action": "Allow",
-				"ip_range": "63.65.120.22"
+				"ip_range": "1.1.1.1"
 			}]
 		}]
 	}`)

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -78,7 +78,7 @@ func TestTemplate(t *testing.T) {
 		"network_acls": [{
 			"bypass":         "None",
 			"default_action": "Deny",
-			"ip_rules": ["1.1.1.1/32"]
+			"ip_rules": ["1.1.1.1"]
 		}]
 	}`)
 	acrNameRegex := regexp.MustCompile("\\W")

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -86,7 +86,13 @@ func TestTemplate(t *testing.T) {
 		"name":                "`+acrNameRegex.ReplaceAllString("isolated-service-"+workspace+"-azcr", "")+`",
 		"resource_group_name": "isolated-service-`+workspace+`-app-rg",
 		"sku":                 "Premium",
-		"network_rule_set":    [{ "default_action": "Deny" }]
+		"network_rule_set":    [{
+			"default_action": "Deny",
+			"ip_rule": [{
+				"action": "Allow",
+				"ip_range": "63.65.120.22"
+			}]
+		}]
 	}`)
 	expectedAppServiceEnvID := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/hostingEnvironments/%s",

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -85,7 +85,8 @@ func TestTemplate(t *testing.T) {
 		"admin_enabled":       true,
 		"name":                "`+acrNameRegex.ReplaceAllString("isolated-service-"+workspace+"-azcr", "")+`",
 		"resource_group_name": "isolated-service-`+workspace+`-app-rg",
-		"sku":                 "Premium"
+		"sku":                 "Premium",
+		"network_rule_set":    [{ "default_action": "Deny" }]
 	}`)
 	expectedAppServiceEnvID := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/hostingEnvironments/%s",
@@ -160,7 +161,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:             tfOptions,
 		Workspace:             workspace,
 		PlanAssertions:        nil,
-		ExpectedResourceCount: 23,
+		ExpectedResourceCount: 22,
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{
 			"azurerm_resource_group.app_rg":                                                expectedAppDevResourceGroup,
 			"azurerm_resource_group.admin_rg":                                              expectedAdminResourceGroup,

--- a/infra/templates/az-isolated-service-single-region/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/variables.tf
@@ -144,6 +144,15 @@ variable "app_dev_subscription_id" {
 }
 
 
+// ---- Networking For App Dev Resources ----
+
+variable "resource_ip_whitelist" {
+  description = "A list of IPs and/or IP ranges that should have access to VNET isolated resources provisioned by this template"
+  type        = list(string)
+  default     = []
+}
+
+
 # Note: We won't be supporting monitoring rules until we have more direction from the
 # customer about how they will use these... However, the schema is useful so I'll keep
 # it defined here.

--- a/infra/templates/az-isolated-service-single-region/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/variables.tf
@@ -152,7 +152,6 @@ variable "resource_ip_whitelist" {
   default     = []
 }
 
-
 # Note: We won't be supporting monitoring rules until we have more direction from the
 # customer about how they will use these... However, the schema is useful so I'll keep
 # it defined here.


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)? Yes
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them? Yes
* [YES/NO] I have updated the documentation accordingly. Yes
* [YES/NO/NA] I have added tests to cover my changes. Yes
* [YES/NO/NA] All new and existing tests passed. Yes
* [YES/NO/NA] My code follows the code style of this project. Yes
* [YES/NO/NA] I ran lint checks locally prior to submission. Yeas
* [YES/NO] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? Yes

## What is the current behavior?
-------------------------------------
Access to the VNET resources based on a whitelisted IP were not being allowed by ACR and Keyvault. More details on the story below  
https://github.com/microsoft/cobalt/issues/232

Issue Number: 232


## What is the new behavior?
-------------------------------------
access enabled to VNET integrated resources based on an IP whitelist so that resources from within express route connected network are able to have the proper access

-
-
-

## Does this introduce a breaking change?
-------------------------------------
- [YES/NO] NO

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
-------------------------------------
