### PR TITLE
Update pipelines to support version-n-go process

### DIFF
--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
@@ -26,7 +26,7 @@ jobs:
   - job: Build_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
     pool: $(AGENT_POOL)
-    condition: or(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
+    condition: or(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true'))
 
     variables:
     - group: '${{ parameters.environment }} Environment Variables'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
@@ -1,13 +1,16 @@
 parameters:
-  alwaysRun: 'false'
   environment: ''
   configurationMatrix: []
+  forceRun: false
+  skipTests: false
 
 jobs:
 
 - job: TemplateChangeDetection
+  variables:
+  - group: '${{ parameters.environment }} Environment Variables'
   displayName: Determine CI Targets to Run
-  condition: ne(${{ parameters.alwaysRun }}, 'true')
+  condition: not(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}))
   steps:
   - ${{ each config in parameters.configurationMatrix }}:
     - task: Bash@3
@@ -23,7 +26,7 @@ jobs:
   - job: Build_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
     pool: $(AGENT_POOL)
-    condition: or(eq(${{ parameters.alwaysRun }}, 'true'), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true'))
+    condition: or(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
 
     variables:
     - group: '${{ parameters.environment }} Environment Variables'
@@ -66,14 +69,16 @@ jobs:
     - task: Bash@3
       name: SetupGitCredentialInjection
       displayName: Configure Git to use PAT
-      condition: eq(${{ coalesce(config.overrideGitPAT, 'false') }}, 'true')
+      condition: ne(variables.TEMPLATE_REPO_PAT, '')
       inputs:
         targetType: 'inline'
-        script: '[[ -z $(TEMPLATE_REPO_PAT) ]] && echo "No PAT provided; skipping." || git config --global url."https://cobalt:$(TEMPLATE_REPO_PAT)@".insteadOf "https://"'
+        script: '[[ -z $SecretPAT ]] && echo "No PAT provided; skipping." || git config --global url."https://cobalt:$SecretPAT@".insteadOf "https://"'
+      env:
+        SecretPAT: $(TEMPLATE_REPO_PAT)
 
     - task: AzureCLI@1
       displayName: 'Unit Test Terraform Template'
-      condition: ne(${{ coalesce(config.skipTests, 'false') }}, 'true')
+      condition: not(coalesce(variables.SKIP_TESTS, ${{ parameters.skipTests }}))
       inputs:
         azureSubscription: '$(SERVICE_CONNECTION_NAME)'
         scriptPath: './$(BUILD_ARTIFACT_NAME)/$(PIPELINE_ROOT_DIR)/$(SCRIPTS_DIR)/test-unit.sh'
@@ -97,10 +102,13 @@ jobs:
     - task: Bash@3
       name: TeardownGitCredentialInjection
       displayName: Reset Git configuration
-      condition: and(always(), eq(${{ coalesce(config.overrideGitPAT, 'false') }}, 'true'))
+      condition: and(always(), ne(variables.TEMPLATE_REPO_PAT, ''))
       inputs:
         targetType: 'inline'
-        script: '[[ -z $(TEMPLATE_REPO_PAT) ]] && echo "No PAT provided; skipping." || git config --global --unset url."https://cobalt:$(TEMPLATE_REPO_PAT)@".insteadOf'
+        script: '[[ -z $SecretPAT ]] && echo "No PAT provided; skipping." || git config --global --unset url."https://cobalt:$SecretPAT@".insteadOf'
+      env:
+        SecretPAT: $(TEMPLATE_REPO_PAT)
+
 
     - task: AzureCLI@1
       displayName: 'Create Terraform Execution Plan'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
@@ -1,4 +1,5 @@
 parameters:
+  alwaysRun: 'false'
   environment: ''
   configurationMatrix: []
 
@@ -6,6 +7,7 @@ jobs:
 
 - job: TemplateChangeDetection
   displayName: Determine CI Targets to Run
+  condition: ne(${{ parameters.alwaysRun }}, 'true')
   steps:
   - ${{ each config in parameters.configurationMatrix }}:
     - task: Bash@3
@@ -21,7 +23,7 @@ jobs:
   - job: Build_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
     pool: $(AGENT_POOL)
-    condition: eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
+    condition: or(eq(${{ parameters.alwaysRun }}, 'true'), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true'))
 
     variables:
     - group: '${{ parameters.environment }} Environment Variables'
@@ -61,8 +63,17 @@ jobs:
       inputs:
         version: '$(GO_VERSION)'
 
+    - task: Bash@3
+      name: SetupGitCredentialInjection
+      displayName: Configure Git to use PAT
+      condition: eq(${{ coalesce(config.overrideGitPAT, 'false') }}, 'true')
+      inputs:
+        targetType: 'inline'
+        script: '[[ -z $(TEMPLATE_REPO_PAT) ]] && echo "No PAT provided; skipping." || git config --global url."https://cobalt:$(TEMPLATE_REPO_PAT)@".insteadOf "https://"'
+
     - task: AzureCLI@1
       displayName: 'Unit Test Terraform Template'
+      condition: ne(${{ coalesce(config.skipTests, 'false') }}, 'true')
       inputs:
         azureSubscription: '$(SERVICE_CONNECTION_NAME)'
         scriptPath: './$(BUILD_ARTIFACT_NAME)/$(PIPELINE_ROOT_DIR)/$(SCRIPTS_DIR)/test-unit.sh'
@@ -82,6 +93,14 @@ jobs:
       env:
         TF_VAR_remote_state_account: $(REMOTE_STATE_ACCOUNT)
         TF_VAR_remote_state_container: $(REMOTE_STATE_CONTAINER)
+
+    - task: Bash@3
+      name: TeardownGitCredentialInjection
+      displayName: Reset Git configuration
+      condition: and(always(), eq(${{ coalesce(config.overrideGitPAT, 'false') }}, 'true'))
+      inputs:
+        targetType: 'inline'
+        script: '[[ -z $(TEMPLATE_REPO_PAT) ]] && echo "No PAT provided; skipping." || git config --global --unset url."https://cobalt:$(TEMPLATE_REPO_PAT)@".insteadOf'
 
     - task: AzureCLI@1
       displayName: 'Create Terraform Execution Plan'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
@@ -1,13 +1,16 @@
 parameters:
-  alwaysRun: 'false'
   environment: ''
   configurationMatrix: []
+  forceRun: false
+  skipTests: false
 
 jobs:
 
 - job: TemplateChangeDetection
+  variables:
+  - group: '${{ parameters.environment }} Environment Variables'
   displayName: Determine CD Targets to Run
-  condition: ne(${{ parameters.alwaysRun }}, 'true')
+  condition: not(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}))
   steps:
   - ${{ each config in parameters.configurationMatrix }}:
     - task: Bash@3
@@ -22,7 +25,7 @@ jobs:
 - ${{ each config in parameters.configurationMatrix }}:
   - deployment: Provision_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
-    condition: or(eq(${{ parameters.alwaysRun }}, 'true'), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true'))
+    condition: or(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
 
     ${{ if config.deploymentTimeoutInMinutes }}:
       timeoutInMinutes: '${{ config.deploymentTimeoutInMinutes }}'
@@ -93,7 +96,7 @@ jobs:
 
           - task: AzureCLI@1
             displayName: 'Integration Test Terraform Template'
-            condition: ne(${{ coalesce(config.skipTests, 'false') }}, 'true')
+            condition: not(coalesce(variables.SKIP_TESTS, ${{ parameters.skipTests }}))
             inputs:
               azureSubscription: '$(SERVICE_CONNECTION_NAME)'
               scriptPath: './$(RELEASE_ARTIFACT_NAME)/$(PIPELINE_ROOT_DIR)/$(SCRIPTS_DIR)/test-integration.sh'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
@@ -25,7 +25,7 @@ jobs:
 - ${{ each config in parameters.configurationMatrix }}:
   - deployment: Provision_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
-    condition: or(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
+    condition: or(coalesce(variables.FORCE_RUN, ${{ parameters.forceRun }}), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true'))
 
     ${{ if config.deploymentTimeoutInMinutes }}:
       timeoutInMinutes: '${{ config.deploymentTimeoutInMinutes }}'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
@@ -1,4 +1,5 @@
 parameters:
+  alwaysRun: 'false'
   environment: ''
   configurationMatrix: []
 
@@ -6,6 +7,7 @@ jobs:
 
 - job: TemplateChangeDetection
   displayName: Determine CD Targets to Run
+  condition: ne(${{ parameters.alwaysRun }}, 'true')
   steps:
   - ${{ each config in parameters.configurationMatrix }}:
     - task: Bash@3
@@ -20,7 +22,7 @@ jobs:
 - ${{ each config in parameters.configurationMatrix }}:
   - deployment: Provision_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
-    condition: eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
+    condition: or(eq(${{ parameters.alwaysRun }}, 'true'), eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true'))
 
     ${{ if config.deploymentTimeoutInMinutes }}:
       timeoutInMinutes: '${{ config.deploymentTimeoutInMinutes }}'
@@ -91,6 +93,7 @@ jobs:
 
           - task: AzureCLI@1
             displayName: 'Integration Test Terraform Template'
+            condition: ne(${{ coalesce(config.skipTests, 'false') }}, 'true')
             inputs:
               azureSubscription: '$(SERVICE_CONNECTION_NAME)'
               scriptPath: './$(RELEASE_ARTIFACT_NAME)/$(PIPELINE_ROOT_DIR)/$(SCRIPTS_DIR)/test-integration.sh'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipelines-app.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipelines-app.yml
@@ -1,0 +1,61 @@
+parameters:
+  environments: []
+  configurationMatrix: []
+
+stages:
+
+- stage: PublishBuildArtifact
+  jobs:
+  - job: Publish
+    displayName: Pull scripts and validate agent readiness
+    steps:
+    - task: Bash@3
+      name: PullScripts
+      displayName: Download Cobalt scripts
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Note: This is intentionally inline because applications should only have
+          # a minimal pipeline definition and Terraform module (for Cobalt) in their repo.
+          mkdir cobaltsrcripts
+          cd cobaltsrcripts
+          git init
+          git remote add origin https://github.com/microsoft/cobalt.git
+          git fetch --force --tags --prune --progress --no-recurse-submodules origin
+          git checkout --progress --force origin/master
+    - task: CopyFiles@2
+      displayName: Copy Pipeline Scripts to Artifact Directory
+      inputs:
+        contents: 'devops/**/scripts/*'
+        sourceFolder: $(Build.SourcesDirectory)/cobaltsrcripts
+        targetFolder: $(Build.ArtifactStagingDirectory)
+    - task: CopyFiles@2
+      displayName: Copy Terraform Files to Artifact Directory
+      inputs:
+        contents: 'infra/**'
+        sourceFolder: $(Build.SourcesDirectory)
+        targetFolder: $(Build.ArtifactStagingDirectory)
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact
+      inputs:
+        parallel: true
+        parallelCount: 8
+        artifactName: '$(BUILD_ARTIFACT_NAME)'
+        pathToPublish: $(Build.ArtifactStagingDirectory)
+
+- ${{ each environment in parameters.environments }}:
+  - stage: ${{ environment }}_Build
+    jobs:
+    - template: azure-pipeline-build-stage.yml
+      parameters:
+        alwaysRun: 'true'
+        environment: ${{ environment }}
+        configurationMatrix: ${{ parameters.configurationMatrix }}
+
+  - stage: ${{ environment }}_Release
+    jobs:
+    - template: azure-pipeline-release-stage.yml
+      parameters:
+        alwaysRun: 'true'
+        environment: ${{ environment }}
+        configurationMatrix: ${{ parameters.configurationMatrix }}

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipelines-app.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipelines-app.yml
@@ -48,14 +48,16 @@ stages:
     jobs:
     - template: azure-pipeline-build-stage.yml
       parameters:
-        alwaysRun: 'true'
         environment: ${{ environment }}
         configurationMatrix: ${{ parameters.configurationMatrix }}
+        skipTests: true
+        forceRun: true
 
   - stage: ${{ environment }}_Release
     jobs:
     - template: azure-pipeline-release-stage.yml
       parameters:
-        alwaysRun: 'true'
         environment: ${{ environment }}
         configurationMatrix: ${{ parameters.configurationMatrix }}
+        skipTests: true
+        forceRun: true


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [x] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
Existing Azure DevOps pipelines required tests to always be run, and checked to see if there were changes to files before executing the build/release jobs. It also did not support the version-n-go process because when the build agent attempted to execute a Terraform `init` command, it would fail to pull from private repositories since it did not have valid Git credentials.

Issue Number: #264 #270 


## What is the new behavior?
-------------------------------------
This PR covers the changes to the pipelines to support the existing behavior in addition to allowing (via environment variable or parameter configuration):
- Optionally skipping unit and integration test execution
  - Environment Variable: `SKIP_TESTS`
  - Pipeline Parameter: `skipTests`
- Optionally forcing the build and release jobs to run
  - Environment Variable: `FORCE_RUN`
  - Pipeline Parameter: `forceRun`
- Optionally setting the build agent's Git configuration to inject a PAT as provided by the `TEMPLATE_REPO_PAT` environment variable
- Addition of an application-specific entry template that handles pulling down expected scripts from the repository and sets up the build/release jobs

## Does this introduce a breaking change?
-------------------------------------
No

## Any relevant logs, error output, etc?
-------------------------------------
No

## Other information
-------------------------------------
Tested existing scenario of setting up the template-specific repository (ref: [Getting Started](https://github.com/microsoft/cobalt/blob/master/docs/GETTING_STARTED_ADD_PAT_OWNER.md)). Also tested against new version-n-go process successfully.