### PR TITLE
Resolve issues and concerns with resource naming strategy and naming collisions

### DIFF
--- a/infra/modules/providers/azure/app-service/main.tf
+++ b/infra/modules/providers/azure/app-service/main.tf
@@ -52,7 +52,7 @@ resource "null_resource" "acr_webhook_creation" {
 
   triggers = {
     images_to_deploy = "${join(",", [for config in local.app_configs : config.image])}"
-    acr_name         = var.azure_container_registry_name
+    acr_name         = var.uses_acr
   }
 
   provisioner "local-exec" {

--- a/infra/modules/providers/azure/app-service/main.tf
+++ b/infra/modules/providers/azure/app-service/main.tf
@@ -47,7 +47,7 @@ resource "azurerm_app_service" "appsvc" {
 }
 
 resource "null_resource" "acr_webhook_creation" {
-  count      = var.docker_enable_ci == true && var.azure_container_registry_name != "" ? length(local.app_names) : 0
+  count      = var.docker_enable_ci == true && var.uses_acr ? length(local.app_names) : 0
   depends_on = [azurerm_app_service.appsvc]
 
   triggers = {
@@ -89,7 +89,7 @@ data "azurerm_app_service" "all" {
 
 resource "azurerm_template_deployment" "access_restriction" {
   name                = "access_restriction"
-  count               = var.vnet_name == "" ? 0 : length(local.app_names)
+  count               = var.uses_vnet ? length(local.app_names) : 0
   resource_group_name = data.azurerm_resource_group.appsvc.name
 
   parameters = {

--- a/infra/modules/providers/azure/app-service/main.tf
+++ b/infra/modules/providers/azure/app-service/main.tf
@@ -18,7 +18,7 @@ data "azurerm_app_service_plan" "appsvc" {
 }
 
 resource "azurerm_app_service" "appsvc" {
-  name                = var.app_service_name
+  name                = format("%s-%s", var.app_service_name_prefix, lower(local.app_names[count.index]))
   resource_group_name = data.azurerm_resource_group.appsvc.name
   location            = data.azurerm_resource_group.appsvc.location
   app_service_plan_id = data.azurerm_app_service_plan.appsvc.id
@@ -73,7 +73,7 @@ resource "null_resource" "acr_webhook_creation" {
 
 resource "azurerm_app_service_slot" "appsvc_staging_slot" {
   name                = "staging"
-  app_service_name    = var.app_service_name
+  app_service_name    = format("%s-%s", var.app_service_name_prefix, lower(local.app_names[count.index]))
   count               = length(local.app_names)
   location            = data.azurerm_resource_group.appsvc.location
   resource_group_name = data.azurerm_resource_group.appsvc.name
@@ -93,7 +93,7 @@ resource "azurerm_template_deployment" "access_restriction" {
   resource_group_name = data.azurerm_resource_group.appsvc.name
 
   parameters = {
-    service_name                   = var.app_service_name
+    service_name                   = format("%s-%s", var.app_service_name_prefix, lower(local.app_names[count.index]))
     vnet_subnet_id                 = var.vnet_subnet_id
     access_restriction_name        = local.access_restriction_name
     access_restriction_description = local.access_restriction_description

--- a/infra/modules/providers/azure/app-service/variables.tf
+++ b/infra/modules/providers/azure/app-service/variables.tf
@@ -8,6 +8,12 @@ variable "service_plan_name" {
   type        = string
 }
 
+variable "uses_acr" {
+  description = "Determines whether or not an Azure container registry is being used"
+  type        = bool
+  default     = false
+}
+
 variable "azure_container_registry_name" {
   description = "The name of the azure container registry resource"
   type        = string
@@ -50,6 +56,12 @@ variable "site_config_always_on" {
   description = "Should the app be loaded at all times? Defaults to false."
   type        = string
   default     = true
+}
+
+variable "uses_vnet" {
+  description = "Determines whether or not a virtual network is being used"
+  type        = bool
+  default     = false
 }
 
 variable "vnet_name" {

--- a/infra/templates/az-hello-world/commons.tf
+++ b/infra/templates/az-hello-world/commons.tf
@@ -19,14 +19,15 @@ locals {
   app_id  = random_string.workspace_scope.keepers.app_id
   region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
   ws_name = random_string.workspace_scope.keepers.ws_name
+  suffix = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}%{ if var.randomization_level > 0 }-${random_string.workspace_scope.result}%{ endif }"
-  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
-  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
-  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"
-  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
-  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+  base_name     = "${local.app_id}-${local.ws_name}${suffix}"
+  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}${suffix}"
+  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}${suffix}"
+  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}${suffix}"
+  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}${suffix}"
+  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}${suffix}"
 
   // Resolved resource names
   app_rg_name      = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)

--- a/infra/templates/az-hello-world/commons.tf
+++ b/infra/templates/az-hello-world/commons.tf
@@ -9,34 +9,34 @@ resource "random_string" "workspace_scope" {
     app_id  = replace(trimspace(lower(var.name)), "_", "-")
   }
 
-  length = max(1, var.randomization_level) // error for zero-length
+  length  = max(1, var.randomization_level) // error for zero-length
   special = false
-  upper = false
+  upper   = false
 }
 
 locals {
   // sanitize names
   app_id  = random_string.workspace_scope.keepers.app_id
-  region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
+  region  = replace(trimspace(lower(var.resource_group_location)), "_", "-")
   ws_name = random_string.workspace_scope.keepers.ws_name
-  suffix = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
+  suffix  = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}${local.suffix}"
-  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
-  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
-  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
-  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
-  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
+  base_name    = "${local.app_id}-${local.ws_name}${local.suffix}"
+  base_name_21 = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
+  base_name_46 = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
+  base_name_60 = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
+  base_name_76 = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
+  base_name_83 = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
 
   // Resolved resource names
-  app_rg_name         = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
-  sp_name             = "${local.base_name}-sp"                      // service plan
+  app_rg_name         = "${local.base_name_83}-app-rg" // app resource group (max 90 chars)
+  sp_name             = "${local.base_name}-sp"        // service plan
   app_svc_name_prefix = local.base_name
 
   // Resolved TF Vars
-  reg_url          = var.docker_registry_server_url
-  app_services     = {
+  reg_url = var.docker_registry_server_url
+  app_services = {
     for target in var.deployment_targets :
     target.app_name => {
       image = "${target.image_name}:${target.image_release_tag_prefix}"

--- a/infra/templates/az-hello-world/commons.tf
+++ b/infra/templates/az-hello-world/commons.tf
@@ -4,7 +4,7 @@ module "provider" {
 
 locals {
   // sanitize names
-  app_id  = replace(trimspace(lower(var.prefix)), "_", "-")
+  app_id  = replace(trimspace(lower(var.name)), "_", "-")
   region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
   ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
 

--- a/infra/templates/az-hello-world/commons.tf
+++ b/infra/templates/az-hello-world/commons.tf
@@ -2,14 +2,26 @@ module "provider" {
   source = "../../modules/providers/azure/provider"
 }
 
+resource "random_string" "workspace_scope" {
+  keepers = {
+    # Generate a new id each time we switch to a new workspace or app id
+    ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+    app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  }
+
+  length = max(1, var.randomization_level) // error for zero-length
+  special = false
+  upper = false
+}
+
 locals {
   // sanitize names
-  app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  app_id  = random_string.workspace_scope.keepers.app_id
   region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
-  ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+  ws_name = random_string.workspace_scope.keepers.ws_name
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}"
+  base_name     = "${local.app_id}-${local.ws_name}%{ if var.randomization_level > 0 }-${random_string.workspace_scope.result}%{ endif }"
   base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
   base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
   base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"

--- a/infra/templates/az-hello-world/commons.tf
+++ b/infra/templates/az-hello-world/commons.tf
@@ -1,0 +1,31 @@
+module "provider" {
+  source = "../../modules/providers/azure/provider"
+}
+
+locals {
+  // sanitize names
+  app_id  = replace(trimspace(lower(var.prefix)), "_", "-")
+  region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
+  ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+
+  // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
+  base_name     = "${local.app_id}-${local.ws_name}"
+  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
+  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
+  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"
+  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+
+  // Resolved resource names
+  app_rg_name      = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
+  sp_name          = "${local.base_name}-sp"                      // service plan
+
+  // Resolved TF Vars
+  reg_url          = var.docker_registry_server_url
+  app_services     = {
+    for target in var.deployment_targets :
+    target.app_name => {
+      image = "${target.image_name}:${target.image_release_tag_prefix}"
+    }
+  }
+}

--- a/infra/templates/az-hello-world/commons.tf
+++ b/infra/templates/az-hello-world/commons.tf
@@ -22,16 +22,17 @@ locals {
   suffix = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}${suffix}"
-  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}${suffix}"
-  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}${suffix}"
-  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}${suffix}"
-  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}${suffix}"
-  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}${suffix}"
+  base_name     = "${local.app_id}-${local.ws_name}${local.suffix}"
+  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
+  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
+  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
+  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
+  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
 
   // Resolved resource names
-  app_rg_name      = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
-  sp_name          = "${local.base_name}-sp"                      // service plan
+  app_rg_name         = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
+  sp_name             = "${local.base_name}-sp"                      // service plan
+  app_svc_name_prefix = local.base_name
 
   // Resolved TF Vars
   reg_url          = var.docker_registry_server_url

--- a/infra/templates/az-hello-world/main.tf
+++ b/infra/templates/az-hello-world/main.tf
@@ -4,26 +4,21 @@ module "provider" {
 }
 
 resource "azurerm_resource_group" "main" {
-  name     = var.prefix
-  location = var.resource_group_location
+  name     = local.app_rg_name
+  location = local.region
 }
 
 module "service_plan" {
   source              = "../../modules/providers/azure/service-plan"
   resource_group_name = azurerm_resource_group.main.name
-  service_plan_name   = "${azurerm_resource_group.main.name}-sp"
+  service_plan_name   = local.sp_name
 }
 
 module "app_service" {
   source                           = "../../modules/providers/azure/app-service"
   service_plan_name                = module.service_plan.service_plan_name
   service_plan_resource_group_name = azurerm_resource_group.main.name
-  docker_registry_server_url       = var.docker_registry_server_url
-  app_service_config = {
-    for target in var.deployment_targets :
-    target.app_name => {
-      image = "${target.image_name}:${target.image_release_tag_prefix}"
-    }
-  }
+  docker_registry_server_url       = local.reg_url
+  app_service_config               = local.app_services
 }
 

--- a/infra/templates/az-hello-world/main.tf
+++ b/infra/templates/az-hello-world/main.tf
@@ -1,8 +1,3 @@
-
-module "provider" {
-  source = "../../modules/providers/azure/provider"
-}
-
 resource "azurerm_resource_group" "main" {
   name     = local.app_rg_name
   location = local.region

--- a/infra/templates/az-hello-world/main.tf
+++ b/infra/templates/az-hello-world/main.tf
@@ -11,6 +11,7 @@ module "service_plan" {
 
 module "app_service" {
   source                           = "../../modules/providers/azure/app-service"
+  app_service_name_prefix          = local.app_svc_name_prefix
   service_plan_name                = module.service_plan.service_plan_name
   service_plan_resource_group_name = azurerm_resource_group.main.name
   docker_registry_server_url       = local.reg_url

--- a/infra/templates/az-hello-world/terraform.tfvars
+++ b/infra/templates/az-hello-world/terraform.tfvars
@@ -3,11 +3,11 @@
 # responsibility to choose the values that make sense for your application.
 #
 # Note: These values will impact the names of resources. If your deployment
-# fails due to a resource name colision, consider using different values for
-# the `prefix` variable.
+# fails due to a resource name collision, consider using different values for
+# the `name` variable.
 
 resource_group_location = "eastus"
-prefix                  = "az-hello-world"
+name                  = "az-hello-world"
 deployment_targets = [{
   app_name                 = "cobalt-backend-api",
   image_name               = "appsvcsample/static-site",

--- a/infra/templates/az-hello-world/terraform.tfvars
+++ b/infra/templates/az-hello-world/terraform.tfvars
@@ -4,13 +4,13 @@
 #
 # Note: These values will impact the names of resources. If your deployment
 # fails due to a resource name collision, consider using different values for
-# the `name` variable.
+# the `name` variable or increasing the value for `randomization_level`.
 
 resource_group_location = "eastus"
-name                  = "az-hello-world"
+name                    = "az-hello-world"
+randomization_level     = 0
 deployment_targets = [{
   app_name                 = "cobalt-backend-api",
   image_name               = "appsvcsample/static-site",
   image_release_tag_prefix = "latest"
 }]
-

--- a/infra/templates/az-hello-world/terraform.tfvars
+++ b/infra/templates/az-hello-world/terraform.tfvars
@@ -8,7 +8,8 @@
 
 resource_group_location = "eastus"
 name                    = "az-hello-world"
-randomization_level     = 0
+randomization_level     = 8
+
 deployment_targets = [{
   app_name                 = "cobalt-backend-api",
   image_name               = "appsvcsample/static-site",

--- a/infra/templates/az-hello-world/tests/unit/az_hw_test.go
+++ b/infra/templates/az-hello-world/tests/unit/az_hw_test.go
@@ -18,7 +18,7 @@ var tfOptions = &terraform.Options{
 	TerraformDir: "../../",
 	Upgrade:      true,
 	Vars: map[string]interface{}{
-		"prefix":                  prefix,
+		"name":                    prefix,
 		"resource_group_location": datacenter,
 	},
 	BackendConfig: map[string]interface{}{

--- a/infra/templates/az-hello-world/tests/unit/az_hw_test.go
+++ b/infra/templates/az-hello-world/tests/unit/az_hw_test.go
@@ -31,7 +31,7 @@ func TestAzureSimple(t *testing.T) {
 	testFixture := infratests.UnitTestFixture{
 		GoTest:                t,
 		TfOptions:             tfOptions,
-		ExpectedResourceCount: 9,
+		ExpectedResourceCount: 10,
 		PlanAssertions:        nil,
 		Workspace:             workspace,
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{

--- a/infra/templates/az-hello-world/tests/unit/az_hw_test.go
+++ b/infra/templates/az-hello-world/tests/unit/az_hw_test.go
@@ -36,7 +36,6 @@ func TestAzureSimple(t *testing.T) {
 		Workspace:             workspace,
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{
 			"module.app_service.azurerm_app_service.appsvc[0]": map[string]interface{}{
-				"resource_group_name": prefix,
 				"app_settings": map[string]interface{}{
 					"WEBSITES_ENABLE_APP_SERVICE_STORAGE": "false",
 				},
@@ -53,7 +52,6 @@ func TestAzureSimple(t *testing.T) {
 			},
 			"azurerm_resource_group.main": map[string]interface{}{
 				"location": datacenter,
-				"name":     prefix,
 			},
 		},
 	}

--- a/infra/templates/az-hello-world/variables.tf
+++ b/infra/templates/az-hello-world/variables.tf
@@ -1,12 +1,18 @@
-variable "prefix" {
-  description = "The prefix used for all resources in this example"
+// ---- General Configuration ----
+
+variable "name" {
+  description = "An identifier used to construct the names of all resources in this template."
   type        = string
 }
 
 variable "resource_group_location" {
-  description = "The Azure location where all resources in this example should be created."
+  description = "The Azure region where all resources in this template should be created."
   type        = string
 }
+
+
+
+// ---- App Service Configuration ----
 
 variable "deployment_targets" {
   description = "Metadata about apps to deploy, such as image metadata."

--- a/infra/templates/az-hello-world/variables.tf
+++ b/infra/templates/az-hello-world/variables.tf
@@ -5,6 +5,12 @@ variable "name" {
   type        = string
 }
 
+variable "randomization_level" {
+  description = "Number of additional random characters to include in resource names to insulate against unexpected resource name collisions."
+  type        = number
+  default     = 8
+}
+
 variable "resource_group_location" {
   description = "The Azure region where all resources in this template should be created."
   type        = string

--- a/infra/templates/az-isolated-service-single-region/app.tf
+++ b/infra/templates/az-isolated-service-single-region/app.tf
@@ -26,14 +26,14 @@ resource "azurerm_management_lock" "app_rg_lock" {
 }
 
 // Query for the subnets within the VNET that lives in the admin subscription
-data "external" "ase_subnets" {
-  program = [
-    "${path.module}/query_subnet_vnet_ids.sh",
-    local.ase_sub_id,
-    var.ase_resource_group,
-    var.ase_vnet_name
-  ]
-}
+#data "external" "ase_subnets" {
+#  program = [
+#    "${path.module}/query_subnet_vnet_ids.sh",
+#    local.ase_sub_id,
+#    var.ase_resource_group,
+#    var.ase_vnet_name
+#  ]
+#}
 
 module "keyvault" {
   source              = "../../modules/providers/azure/keyvault"

--- a/infra/templates/az-isolated-service-single-region/app.tf
+++ b/infra/templates/az-isolated-service-single-region/app.tf
@@ -10,12 +10,12 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "app_rg" {
   name     = local.app_rg_name
-  location = var.resource_group_location
+  location = local.region
   provider = azurerm.app_dev
 }
 
 resource "azurerm_management_lock" "app_rg_lock" {
-  name       = format("%s-delete-lock", local.app_rg_name)
+  name       = local.app_rg_lock
   scope      = azurerm_resource_group.app_rg.id
   lock_level = "CanNotDelete"
   provider   = azurerm.app_dev
@@ -64,7 +64,7 @@ module "container_registry" {
 module "app_service_principal_contributor" {
   source          = "../../modules/providers/azure/service-principal"
   create_for_rbac = true
-  display_name    = local.svc_principal_name
+  display_name    = local.svc_princ_name
   role_name       = "Contributor"
   role_scope      = "${module.container_registry.container_registry_id}"
 }
@@ -90,7 +90,7 @@ module "app_service_principal_secrets" {
 module "acr_service_principal_acrpull" {
   source          = "../../modules/providers/azure/service-principal"
   create_for_rbac = true
-  display_name    = local.acr_svc_principal_name
+  display_name    = local.acr_svc_princ_name
   role_name       = "acrpull"
   role_scope      = "${module.container_registry.container_registry_id}"
 }

--- a/infra/templates/az-isolated-service-single-region/app.tf
+++ b/infra/templates/az-isolated-service-single-region/app.tf
@@ -26,14 +26,14 @@ resource "azurerm_management_lock" "app_rg_lock" {
 }
 
 // Query for the subnets within the VNET that lives in the admin subscription
-#data "external" "ase_subnets" {
-#  program = [
-#    "${path.module}/query_subnet_vnet_ids.sh",
-#    local.ase_sub_id,
-#    var.ase_resource_group,
-#    var.ase_vnet_name
-#  ]
-#}
+data "external" "ase_subnets" {
+  program = [
+    "${path.module}/query_subnet_vnet_ids.sh",
+    local.ase_sub_id,
+    var.ase_resource_group,
+    var.ase_vnet_name
+  ]
+}
 
 module "keyvault" {
   source              = "../../modules/providers/azure/keyvault"

--- a/infra/templates/az-isolated-service-single-region/ase.tf
+++ b/infra/templates/az-isolated-service-single-region/ase.tf
@@ -56,6 +56,7 @@ module "app_service" {
   app_service_name_prefix          = local.app_svc_name_prefix
   service_plan_resource_group_name = azurerm_resource_group.admin_rg.name
   app_insights_instrumentation_key = module.app_insights.app_insights_instrumentation_key
+  uses_acr                         = true
   azure_container_registry_name    = module.container_registry.container_registry_name
   docker_registry_server_url       = module.container_registry.container_registry_login_server
   docker_registry_server_username  = module.acr_service_principal_acrpull.service_principal_application_id
@@ -77,6 +78,7 @@ module "authn_app_service" {
   app_service_name_prefix          = local.auth_svc_name_prefix
   service_plan_resource_group_name = azurerm_resource_group.admin_rg.name
   app_insights_instrumentation_key = module.app_insights.app_insights_instrumentation_key
+  uses_acr                         = true
   azure_container_registry_name    = module.container_registry.container_registry_name
   docker_registry_server_url       = module.container_registry.container_registry_login_server
   docker_registry_server_username  = module.container_registry.admin_username

--- a/infra/templates/az-isolated-service-single-region/ase.tf
+++ b/infra/templates/az-isolated-service-single-region/ase.tf
@@ -53,7 +53,7 @@ module "service_plan" {
 module "app_service" {
   source                           = "../../modules/providers/azure/app-service"
   service_plan_name                = module.service_plan.service_plan_name
-  app_service_name                 = local.app_service_name
+  app_service_name_prefix          = local.app_svc_name_prefix
   service_plan_resource_group_name = azurerm_resource_group.admin_rg.name
   app_insights_instrumentation_key = module.app_insights.app_insights_instrumentation_key
   azure_container_registry_name    = module.container_registry.container_registry_name
@@ -74,6 +74,7 @@ module "app_service" {
 module "authn_app_service" {
   source                           = "../../modules/providers/azure/app-service"
   service_plan_name                = module.service_plan.service_plan_name
+  app_service_name_prefix          = local.auth_svc_name_prefix
   service_plan_resource_group_name = azurerm_resource_group.admin_rg.name
   app_insights_instrumentation_key = module.app_insights.app_insights_instrumentation_key
   azure_container_registry_name    = module.container_registry.container_registry_name

--- a/infra/templates/az-isolated-service-single-region/ase.tf
+++ b/infra/templates/az-isolated-service-single-region/ase.tf
@@ -10,12 +10,12 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "admin_rg" {
   name     = local.admin_rg_name
-  location = var.resource_group_location
+  location = local.region
   provider = azurerm.admin
 }
 
 resource "azurerm_management_lock" "admin_rg_lock" {
-  name       = format("%s-delete-lock", local.admin_rg_name)
+  name       = local.admin_rg_lock
   scope      = azurerm_resource_group.admin_rg.id
   lock_level = "CanNotDelete"
   provider   = azurerm.admin

--- a/infra/templates/az-isolated-service-single-region/commons.tf
+++ b/infra/templates/az-isolated-service-single-region/commons.tf
@@ -6,19 +6,32 @@ data "azurerm_subscription" "current" {}
 
 data "azurerm_client_config" "current" {}
 
+resource "random_string" "workspace_scope" {
+  keepers = {
+    # Generate a new id each time we switch to a new workspace or app id
+    ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+    app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  }
+
+  length = max(1, var.randomization_level) // error for zero-length
+  special = false
+  upper = false
+}
+
 locals {
   // sanitize names
-  app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  app_id  = random_string.workspace_scope.keepers.app_id
   region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
-  ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+  ws_name = random_string.workspace_scope.keepers.ws_name
+  suffix = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}"
-  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
-  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
-  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"
-  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
-  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+  base_name     = "${local.app_id}-${local.ws_name}${local.suffix}"
+  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
+  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
+  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
+  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
+  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
 
   tenant_id     = data.azurerm_client_config.current.tenant_id
 

--- a/infra/templates/az-isolated-service-single-region/commons.tf
+++ b/infra/templates/az-isolated-service-single-region/commons.tf
@@ -7,16 +7,44 @@ data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
 
 locals {
-  prefix        = "${lower(var.name)}-${lower(terraform.workspace)}"
+  // sanitize names
+  app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
+  ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+
+  // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
+  base_name     = "${local.app_id}-${local.ws_name}"
+  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
+  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
+  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"
+  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+
   tenant_id     = data.azurerm_client_config.current.tenant_id
-  admin_rg_name = "${local.prefix}-admin-rg"                                                                                             // name of resource group used for admin resources
-  app_rg_name   = "${local.prefix}-app-rg"                                                                                               // name of app resource group
-  sp_name       = "${local.prefix}-sp"                                                                                                   // name of service plan
-  ai_name       = "${local.prefix}-ai"                                                                                                   // name of app insights
-  kv_name       = format("%s%s-kv", format("%.10s", lower(var.name)), format("%.10s", lower(terraform.workspace)))                       // name of key vault
-  acr_name      = replace(format("%s%sacr", format("%.10s", lower(var.name)), format("%.10s", lower(terraform.workspace))), "/\\W/", "") // name of acr
-  ase_sub_id    = var.ase_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.ase_subscription_id
-  app_sub_id    = var.app_dev_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.app_dev_subscription_id
+
+  // Resource names
+  admin_rg_name      = "${local.base_name_83}-adm-rg"               // resource group used for admin resources (max 90 chars)
+  app_rg_name        = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
+  admin_rg_lock      = "${local.base_name_83}-adm-rg-delete-lock"   // management lock to prevent deletes
+  app_rg_lock        = "${local.base_name_83}-app-rg-delete-lock"   // management lock to prevent deletes
+  sp_name            = "${local.base_name}-sp"                      // service plan
+  ai_name            = "${local.base_name}-ai"                      // app insights
+  kv_name            = "${local.base_name_21}-kv"                   // key vault (max 24 chars)
+  acr_name           = "${replace(local.base_name_46, "-", "")}acr" // container registry (max 50 chars, alphanumeric *only*)
+  vnet_name          = "${local.base_name_60}-net"                  // virtual network (max 64 chars)
+  tm_profile_name    = "${local.base_name_60}-tf"                   // traffic manager profile (max 63 chars)
+  tm_endpoint_name   = "${local.region}_${local.app_id}"            // traffic manager endpoint
+  tm_dns_name        = "${local.base_name}-dns"                     // traffic manager dns relative name
+  appgateway_name    = "${local.base_name_76}-gw"                   // app gateway (max 80 chars)
+  public_pip_name    = "${local.base_name_76}-ip"                   // public IP (max 80 chars)
+  svc_princ_name     = "${local.base_name}-svc-principal"           // service principal
+  acr_svc_princ_name = "${local.base_name}-acr-svc-principal"       // container registry service principal
+
+  // Resolved TF Vars
+  ase_sub_id           = var.ase_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.ase_subscription_id
+  app_sub_id           = var.app_dev_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.app_dev_subscription_id
+  // id of App Service Environment
+  ase_id = "/subscriptions/${local.ase_sub_id}/resourceGroups/${var.ase_resource_group}/providers/Microsoft.Web/hostingEnvironments/${var.ase_name}"
 
   app_secrets = {
     "app-service-principal-object-id"      = module.app_service_principal_contributor.service_principal_object_id,
@@ -33,8 +61,4 @@ locals {
   acr_password = {
     "acr-service-principal-password" = module.acr_service_principal_acrpull.service_principal_password
   }
-  svc_principal_name     = "${local.prefix}-svc-principal"
-  acr_svc_principal_name = "${local.prefix}-acr-svc-principal"
-  // id of App Service Environment
-  ase_id = "/subscriptions/${local.ase_sub_id}/resourceGroups/${var.ase_resource_group}/providers/Microsoft.Web/hostingEnvironments/${var.ase_name}"
 }

--- a/infra/templates/az-isolated-service-single-region/commons.tf
+++ b/infra/templates/az-isolated-service-single-region/commons.tf
@@ -13,27 +13,27 @@ resource "random_string" "workspace_scope" {
     app_id  = replace(trimspace(lower(var.name)), "_", "-")
   }
 
-  length = max(1, var.randomization_level) // error for zero-length
+  length  = max(1, var.randomization_level) // error for zero-length
   special = false
-  upper = false
+  upper   = false
 }
 
 locals {
   // sanitize names
   app_id  = random_string.workspace_scope.keepers.app_id
-  region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
+  region  = replace(trimspace(lower(var.resource_group_location)), "_", "-")
   ws_name = random_string.workspace_scope.keepers.ws_name
-  suffix = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
+  suffix  = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}${local.suffix}"
-  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
-  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
-  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
-  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
-  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
+  base_name    = "${local.app_id}-${local.ws_name}${local.suffix}"
+  base_name_21 = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
+  base_name_46 = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
+  base_name_60 = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
+  base_name_76 = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
+  base_name_83 = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
 
-  tenant_id     = data.azurerm_client_config.current.tenant_id
+  tenant_id = data.azurerm_client_config.current.tenant_id
 
   // Resource names
   admin_rg_name        = "${local.base_name_83}-adm-rg"               // resource group used for admin resources (max 90 chars)
@@ -56,8 +56,8 @@ locals {
   auth_svc_name_prefix = "${local.base_name}-au"
 
   // Resolved TF Vars
-  ase_sub_id           = var.ase_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.ase_subscription_id
-  app_sub_id           = var.app_dev_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.app_dev_subscription_id
+  ase_sub_id = var.ase_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.ase_subscription_id
+  app_sub_id = var.app_dev_subscription_id == "" ? data.azurerm_subscription.current.subscription_id : var.app_dev_subscription_id
   // id of App Service Environment
   ase_id = "/subscriptions/${local.ase_sub_id}/resourceGroups/${var.ase_resource_group}/providers/Microsoft.Web/hostingEnvironments/${var.ase_name}"
 

--- a/infra/templates/az-isolated-service-single-region/docs/design.md
+++ b/infra/templates/az-isolated-service-single-region/docs/design.md
@@ -79,18 +79,48 @@ Only one terraform template can be deployed within a given workspace. The use ca
 ## Module and Template Deep Dive
 
 ### Template Inputs
+General Configuration
 | name | type | default | description |
 |---|---|---|---|
-| `resource_group_location` | string |  | The deployment location of resource group container all the resources |
-| `name` | string |  | The name of the deployment.  This will be used across the resource created in this solution |
-| `app_service_containers` | map(str) |  | The name key value pair where the key is the name assigned to the app service and value is the source container |
-| `metrics_configuration` | MetricsConfig **see below** | `[]` | A list of metrics configuration that should be configured for the app service plan |
+| `resource_group_location` | string |  | The Azure region where all resources in this template should be created |
+| `name` | string |  | It serves as an identifier used to construct the names of all resources in this template 
+| `randomization_level` | number |  | Number of additional random characters to include in resource names to insulate against unexpected resource name collisions |
+
+App Service Environment Configuration
+| name | type | default | description |
+|---|---|---|---|
+| `app_service_containers` | string |  | The ID of the subscription in which the ASE lives in |
+| `ase_name` | string |  | The name of the App Service Environment in which to deploy the app services |
+| `ase_resource_group` | string | | The resource group of the App Service Environment in which to deploy the app services |
 | `monitoring_dimension_values` | `["*"]` |  | Dimensions used to determine service plan scaling |
-| `ase_vnet_name` | string |  | The name of the VNET in which the ASE lives |
-| `service_plan_scaling_rules` | list(rule) **see below** | `[]` | A list of scaline rules to apply to the service plan
-| `provision_sql` | bool | `false` | True if SQL Server should be deployed, false otherwise
-| `provision_storage_account` | bool | `false` | True if s storage account should be deployed, false otherwise
-| `authenticated_clients` | list(string) | `[]` | List of clients to authenticate if `enable_auth` is true
+| `ase_vnet_name` | string |  | The name of the VNET that the App Service Environment is deployed to |
+
+App Service Configuration
+| name | type | default | description |
+|---|---|---|---|
+| `unauthn_deployment_targets` | list(obj) |  | DMetadata about apps to deploy, such as repository location, docker file metadata and image names |
+| `authn_deployment_targets` | list(obj) |  | Metadata about apps to deploy that also require authentication | 
+
+Service Plan Configuration
+| name | type | default | description |
+|---|---|---|---|
+| `monitoring_dimension_values` | `["*"]` |  | Dimensions used to determine service plan scaling |
+| `service_plan_size` | string |  | The size of the service plan instance. Valid values are I1, I2, I3 |
+| `service_plan_kind` | string |  | The kind of Service Plan to be created. Possible values are Windows/Linux/FunctionApp/App |
+| `scaling_rules` | list(obj) |  | The scaling rules for the app service plan. |
+
+App Service Authentication Configuration
+| name | type | default | description |
+|---|---|---|---|
+| `auth_suffix` | string |  | easy-auth | A name to be appended to all azure ad applications
+| `graph_role_id` | string |  | 00000002-0000-0000-c000-000000000000The size of the service plan instance. Valid values are I1, I2, I3 |
+| `graph_id` | string | 00000002-0000-0000-c000-000000000000 | The kind of Service Plan to be created. Possible values are Windows/Linux/FunctionApp/App |
+
+App Dev Subscription and Networking
+| name | type | default | description |
+|---|---|---|---|
+| `App Dev Subscription` | string |  | Subscription in which the application dependencies will be deployed to |
+| `resource_ip_whitelist` | list[string] |  | A list of IPs and/or IP ranges that should have access to VNET isolated resources provisioned by this template |
 
 **Notes**
 

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -32,7 +32,7 @@ unauthn_deployment_targets = [
 
 # Note: this is configured as such only to test IP Whitelists. This is a well
 # known DNS address
-resource_ip_whitelist   = ["13.107.6.0/24", "13.107.9.0/24", "13.107.42.0/24", "13.107.43.0/24", "40.74.0.0/15", "40.76.0.0/14", "40.80.0.0/12", "40.96.0.0/12", "40.112.0.0/13", "40.120.0.0/14", "40.124.0.0/16", "40.125.0.0/17"]
-ase_name                = "co-static-ase"
-ase_resource_group      = "co-static-ase-rg"
-ase_vnet_name           = "co-static-ase-vnet"
+resource_ip_whitelist = ["13.107.6.0/24", "13.107.9.0/24", "13.107.42.0/24", "13.107.43.0/24", "40.74.0.0/15", "40.76.0.0/14", "40.80.0.0/12", "40.96.0.0/12", "40.112.0.0/13", "40.120.0.0/14", "40.124.0.0/16", "40.125.0.0/17"]
+ase_name              = "co-static-ase"
+ase_resource_group    = "co-static-ase-rg"
+ase_vnet_name         = "co-static-ase-vnet"

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -3,7 +3,7 @@
 # responsibility to choose the values that make sense for your application.
 #
 # Note: These values will impact the names of resources. If your deployment
-# fails due to a resource name colision, consider using different values for
+# fails due to a resource name collision, consider using different values for
 # the `name` variable.
 
 authn_deployment_targets = [

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -4,7 +4,11 @@
 #
 # Note: These values will impact the names of resources. If your deployment
 # fails due to a resource name collision, consider using different values for
-# the `name` variable.
+# the `name` variable or increasing the value for `randomization_level`.
+
+resource_group_location = "eastus2"
+name                    = "isolated-service"
+randomization_level     = 8
 
 authn_deployment_targets = [
   {
@@ -30,7 +34,5 @@ unauthn_deployment_targets = [
 # known DNS address
 resource_ip_whitelist   = ["13.107.6.0/24", "13.107.9.0/24", "13.107.42.0/24", "13.107.43.0/24", "40.74.0.0/15", "40.76.0.0/14", "40.80.0.0/12", "40.96.0.0/12", "40.112.0.0/13", "40.120.0.0/14", "40.124.0.0/16", "40.125.0.0/17"]
 ase_name                = "co-static-ase"
-name                    = "isolated-service"
 ase_resource_group      = "co-static-ase-rg"
 ase_vnet_name           = "co-static-ase-vnet"
-resource_group_location = "eastus2"

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -65,17 +65,13 @@ func asMap(t *testing.T, jsonString string) map[string]interface{} {
 func TestTemplate(t *testing.T) {
 	expectedStagingSlot := asMap(t, `{"name":"staging"}`)
 	expectedAppDevResourceGroup := asMap(t, `{
-		"name":     "isolated-service-`+workspace+`-app-rg",
 		"location": "`+region+`"
 	}`)
 	expectedAdminResourceGroup := asMap(t, `{
-		"name":     "isolated-service-`+workspace+`-admin-rg",
 		"location": "`+region+`"
 	}`)
 	expectedAppInsights := asMap(t, `{
-		"name":                "isolated-service-`+workspace+`-ai",
 		"application_type":    "Web",
-		"resource_group_name": "isolated-service-`+workspace+`-admin-rg"
 	}`)
 	// expectedKeyVault := asMap(t, `{
 	// 	"network_acls": [{
@@ -151,9 +147,7 @@ func TestTemplate(t *testing.T) {
 	expectedAppServicePlan := asMap(t, `{
 		"app_service_environment_id": "`+expectedAppServiceEnvID+`", 
 		"kind":                       "Linux",
-		"name":                       "isolated-service-`+workspace+`-sp",
 		"reserved":                   true,
-		"resource_group_name":        "isolated-service-`+workspace+`-admin-rg",
 		"sku": [{ "capacity": 1, "size": "I1", "tier": "Isolated" }]
 	}`)
 	expectedAutoScalePlan := asMap(t, `{
@@ -202,16 +196,12 @@ func TestTemplate(t *testing.T) {
 	}`)
 	expectedAppServiceSchema := `{
 		"identity": [{ "type": "SystemAssigned" }],
-		"name": "co-backend-api-%d-%s",
-		"resource_group_name": "isolated-service-%s-admin-rg",
 		"site_config": [{
 			"always_on": true
 		}]
 	}`
 	expectedAppServiceSchema2 := `{
 		"identity": [{ "type": "SystemAssigned" }],
-		"name": "co-frontend-api-%d-%s",
-		"resource_group_name": "isolated-service-%s-admin-rg",
 		"site_config": [{
 			"always_on": true
 		}]

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -71,7 +71,7 @@ func TestTemplate(t *testing.T) {
 		"location": "`+region+`"
 	}`)
 	expectedAppInsights := asMap(t, `{
-		"application_type":    "Web",
+		"application_type":    "Web"
 	}`)
 	// expectedKeyVault := asMap(t, `{
 	// 	"network_acls": [{
@@ -206,8 +206,8 @@ func TestTemplate(t *testing.T) {
 			"always_on": true
 		}]
 	}`
-	expectedAppService1 := asMap(t, fmt.Sprintf(expectedAppServiceSchema, 1, workspace, workspace))
-	expectedAppService2 := asMap(t, fmt.Sprintf(expectedAppServiceSchema2, 1, workspace, workspace))
+	expectedAppService1 := asMap(t, expectedAppServiceSchema)
+	expectedAppService2 := asMap(t, expectedAppServiceSchema2)
 
 	testFixture := infratests.UnitTestFixture{
 		GoTest:                t,

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -224,7 +224,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:             tfOptions,
 		Workspace:             workspace,
 		PlanAssertions:        nil,
-		ExpectedResourceCount: 49,
+		ExpectedResourceCount: 48,
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{
 			"azurerm_resource_group.app_rg":   expectedAppDevResourceGroup,
 			"azurerm_resource_group.admin_rg": expectedAdminResourceGroup,

--- a/infra/templates/az-isolated-service-single-region/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/variables.tf
@@ -5,6 +5,12 @@ variable "name" {
   type        = string
 }
 
+variable "randomization_level" {
+  description = "Number of additional random characters to include in resource names to insulate against unexpected resource name collisions."
+  type        = number
+  default     = 8
+}
+
 variable "resource_group_location" {
   description = "The Azure region where all resources in this template should be created."
   type        = string

--- a/infra/templates/az-isolated-service-single-region/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/variables.tf
@@ -1,12 +1,12 @@
 // ---- General Configuration ----
 
-variable "resource_group_location" {
-  description = "The deployment location of resource group container all the resources"
+variable "name" {
+  description = "An identifier used to construct the names of all resources in this template."
   type        = string
 }
 
-variable "name" {
-  description = "The name of the deployment. This will be used across the resource created in this solution"
+variable "resource_group_location" {
+  description = "The Azure region where all resources in this template should be created."
   type        = string
 }
 

--- a/infra/templates/az-service-single-region/README.md
+++ b/infra/templates/az-service-single-region/README.md
@@ -97,8 +97,8 @@ terraform destroy
 
 #### Required Variables
 
- 1. `resource_group_location`: The deployment location of resource group container all the resources.
- 2. `name`: The name of the deployment.  This will be used across the resource created in this solution.
+ 1. `resource_group_location`: The deployment location of resource group container all the resource
+ 2. `name`: An identifier used to construct the names of all resources in this template.
  3. `app_service_name`: The name key value pair where the key is representative to the app service name and value is the source container.
 
 #### Optional Variables

--- a/infra/templates/az-service-single-region/admin.tf
+++ b/infra/templates/az-service-single-region/admin.tf
@@ -1,19 +1,5 @@
-locals {
-  prefix              = "${lower(var.name)}-${lower(terraform.workspace)}"
-  prefix_short        = format("%.20s", local.prefix)
-  tm_profile_name     = "${local.prefix}-tf"
-  vnet_name           = "${local.prefix}-vnet"
-  tm_endpoint_name    = "${var.resource_group_location}_${var.name}"
-  tm_dns_name         = "${local.prefix}-dns"
-  appgateway_name     = "${local.prefix}-gateway"
-  public_pip_name     = "${local.prefix}-ip"
-  kv_name             = "${local.prefix_short}kv"
-  acr_name            = "${replace(local.prefix, "-", "")}acr"
-  resource_group_name = "${local.prefix}"
-}
-
 resource "azurerm_resource_group" "svcplan" {
-  name     = local.resource_group_name
+  name     = local.admin_rg_name
   location = var.resource_group_location
 }
 

--- a/infra/templates/az-service-single-region/admin.tf
+++ b/infra/templates/az-service-single-region/admin.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "svcplan" {
   name     = local.admin_rg_name
-  location = var.resource_group_location
+  location = local.region
 }
 
 module "vnet" {
@@ -51,8 +51,8 @@ module "app_gateway" {
 
 module "container_registry" {
   source                           = "../../modules/providers/azure/container-registry"
-  container_registry_name          = var.azure_container_resource_name == "" ? local.acr_name : var.azure_container_resource_name
-  resource_group_name              = var.azure_container_resource_group == "" ? azurerm_resource_group.svcplan.name : var.azure_container_resource_group
+  container_registry_name          = local.resolved_acr_name
+  resource_group_name              = local.resolved_acr_rg_name
   container_registry_admin_enabled = true
   container_registry_tags          = var.azure_container_tags
 }

--- a/infra/templates/az-service-single-region/appdev.tf
+++ b/infra/templates/az-service-single-region/appdev.tf
@@ -1,6 +1,6 @@
 data "azurerm_container_registry" "acr" {
-  name                = module.container_registry.container_registry_name
-  resource_group_name = var.azure_container_resource_group == "" ? azurerm_resource_group.svcplan.name : var.azure_container_resource_group
+  name                = local.resolved_acr_name
+  resource_group_name = local.resolved_acr_rg_name
   depends_on          = ["azurerm_resource_group.svcplan", "module.container_registry"]
 }
 

--- a/infra/templates/az-service-single-region/appdev.tf
+++ b/infra/templates/az-service-single-region/appdev.tf
@@ -1,8 +1,3 @@
-locals {
-  service_plan_name = "${local.prefix}-sp"
-  app_insights_name = "${local.prefix}-ai"
-}
-
 data "azurerm_container_registry" "acr" {
   name                = module.container_registry.container_registry_name
   resource_group_name = var.azure_container_resource_group == "" ? azurerm_resource_group.svcplan.name : var.azure_container_resource_group
@@ -32,14 +27,10 @@ resource "null_resource" "acr_image_deploy" {
   }
 }
 
-module "provider" {
-  source = "../../modules/providers/azure/provider"
-}
-
 module "service_plan" {
   source              = "../../modules/providers/azure/service-plan"
   resource_group_name = azurerm_resource_group.svcplan.name
-  service_plan_name   = local.service_plan_name
+  service_plan_name   = local.sp_name
 }
 
 module "app_service" {
@@ -72,7 +63,7 @@ resource "azurerm_role_assignment" "acr_pull" {
 module "app_insight" {
   source                           = "../../modules/providers/azure/app-insights"
   service_plan_resource_group_name = azurerm_resource_group.svcplan.name
-  appinsights_name                 = local.app_insights_name
+  appinsights_name                 = local.ai_name
   appinsights_application_type     = var.application_type
 }
 

--- a/infra/templates/az-service-single-region/appdev.tf
+++ b/infra/templates/az-service-single-region/appdev.tf
@@ -38,10 +38,12 @@ module "app_service" {
   service_plan_name                = module.service_plan.service_plan_name
   service_plan_resource_group_name = azurerm_resource_group.svcplan.name
   app_insights_instrumentation_key = module.app_insight.app_insights_instrumentation_key
+  uses_acr                         = true
   azure_container_registry_name    = module.container_registry.container_registry_name
   docker_registry_server_url       = module.container_registry.container_registry_login_server
   docker_registry_server_username  = data.azurerm_container_registry.acr.admin_username
   docker_registry_server_password  = data.azurerm_container_registry.acr.admin_password
+  uses_vnet                        = true
   vnet_name                        = module.vnet.vnet_name
   vnet_subnet_id                   = module.vnet.vnet_subnet_ids[0]
   vault_uri                        = module.keyvault.keyvault_uri

--- a/infra/templates/az-service-single-region/commons.tf
+++ b/infra/templates/az-service-single-region/commons.tf
@@ -19,14 +19,15 @@ locals {
   app_id  = random_string.workspace_scope.keepers.app_id
   region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
   ws_name = random_string.workspace_scope.keepers.ws_name
+  suffix = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}%{ if var.randomization_level > 0 }-${random_string.workspace_scope.result}%{ endif }"
-  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
-  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
-  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"
-  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
-  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+  base_name     = "${local.app_id}-${local.ws_name}${local.suffix}"
+  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
+  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
+  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
+  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
+  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
 
   // Resource names
   admin_rg_name    = "${local.base_name_83}-adm-rg"               // resource group used for admin resources (max 90 chars)

--- a/infra/templates/az-service-single-region/commons.tf
+++ b/infra/templates/az-service-single-region/commons.tf
@@ -29,5 +29,9 @@ locals {
   tm_dns_name      = "${local.base_name}-dns"                     // traffic manager dns relative name
   appgateway_name  = "${local.base_name_76}-gw"                   // app gateway (max 80 chars)
   public_pip_name  = "${local.base_name_76}-ip"                   // public IP (max 80 chars)
+
+  // Resolved TF Vars
+  resolved_acr_rg_name = var.azure_container_resource_group == "" ? local.admin_rg_name : var.azure_container_resource_group
+  resolved_acr_name    = var.azure_container_resource_name == "" ? local.acr_name : var.azure_container_resource_name
 }
 

--- a/infra/templates/az-service-single-region/commons.tf
+++ b/infra/templates/az-service-single-region/commons.tf
@@ -9,25 +9,25 @@ resource "random_string" "workspace_scope" {
     app_id  = replace(trimspace(lower(var.name)), "_", "-")
   }
 
-  length = max(1, var.randomization_level) // error for zero-length
+  length  = max(1, var.randomization_level) // error for zero-length
   special = false
-  upper = false
+  upper   = false
 }
 
 locals {
   // sanitize names
   app_id  = random_string.workspace_scope.keepers.app_id
-  region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
+  region  = replace(trimspace(lower(var.resource_group_location)), "_", "-")
   ws_name = random_string.workspace_scope.keepers.ws_name
-  suffix = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
+  suffix  = var.randomization_level > 0 ? "-${random_string.workspace_scope.result}" : ""
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}${local.suffix}"
-  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
-  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
-  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
-  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
-  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
+  base_name    = "${local.app_id}-${local.ws_name}${local.suffix}"
+  base_name_21 = length(local.base_name) < 22 ? local.base_name : "${substr(local.base_name, 0, 21 - length(local.suffix))}${local.suffix}"
+  base_name_46 = length(local.base_name) < 47 ? local.base_name : "${substr(local.base_name, 0, 46 - length(local.suffix))}${local.suffix}"
+  base_name_60 = length(local.base_name) < 61 ? local.base_name : "${substr(local.base_name, 0, 60 - length(local.suffix))}${local.suffix}"
+  base_name_76 = length(local.base_name) < 77 ? local.base_name : "${substr(local.base_name, 0, 76 - length(local.suffix))}${local.suffix}"
+  base_name_83 = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
 
   // Resource names
   admin_rg_name       = "${local.base_name_83}-adm-rg"               // resource group used for admin resources (max 90 chars)

--- a/infra/templates/az-service-single-region/commons.tf
+++ b/infra/templates/az-service-single-region/commons.tf
@@ -30,18 +30,19 @@ locals {
   base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(local.base_name, 0, 83 - length(local.suffix))}${local.suffix}"
 
   // Resource names
-  admin_rg_name    = "${local.base_name_83}-adm-rg"               // resource group used for admin resources (max 90 chars)
-  app_rg_name      = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
-  sp_name          = "${local.base_name}-sp"                      // service plan
-  ai_name          = "${local.base_name}-ai"                      // app insights
-  kv_name          = "${local.base_name_21}-kv"                   // key vault (max 24 chars)
-  acr_name         = "${replace(local.base_name_46, "-", "")}acr" // container registry (max 50 chars, alphanumeric *only*)
-  vnet_name        = "${local.base_name_60}-net"                  // virtual network (max 64 chars)
-  tm_profile_name  = "${local.base_name_60}-tf"                   // traffic manager profile (max 63 chars)
-  tm_endpoint_name = "${local.region}_${local.app_id}"            // traffic manager endpoint
-  tm_dns_name      = "${local.base_name}-dns"                     // traffic manager dns relative name
-  appgateway_name  = "${local.base_name_76}-gw"                   // app gateway (max 80 chars)
-  public_pip_name  = "${local.base_name_76}-ip"                   // public IP (max 80 chars)
+  admin_rg_name       = "${local.base_name_83}-adm-rg"               // resource group used for admin resources (max 90 chars)
+  app_rg_name         = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
+  sp_name             = "${local.base_name}-sp"                      // service plan
+  ai_name             = "${local.base_name}-ai"                      // app insights
+  kv_name             = "${local.base_name_21}-kv"                   // key vault (max 24 chars)
+  acr_name            = "${replace(local.base_name_46, "-", "")}acr" // container registry (max 50 chars, alphanumeric *only*)
+  vnet_name           = "${local.base_name_60}-net"                  // virtual network (max 64 chars)
+  tm_profile_name     = "${local.base_name_60}-tf"                   // traffic manager profile (max 63 chars)
+  tm_endpoint_name    = "${local.region}_${local.app_id}"            // traffic manager endpoint
+  tm_dns_name         = "${local.base_name}-dns"                     // traffic manager dns relative name
+  appgateway_name     = "${local.base_name_76}-gw"                   // app gateway (max 80 chars)
+  public_pip_name     = "${local.base_name_76}-ip"                   // public IP (max 80 chars)
+  app_svc_name_prefix = local.base_name
 
   // Resolved TF Vars
   resolved_acr_rg_name = var.azure_container_resource_group == "" ? azurerm_resource_group.svcplan.name : var.azure_container_resource_group

--- a/infra/templates/az-service-single-region/commons.tf
+++ b/infra/templates/az-service-single-region/commons.tf
@@ -31,7 +31,7 @@ locals {
   public_pip_name  = "${local.base_name_76}-ip"                   // public IP (max 80 chars)
 
   // Resolved TF Vars
-  resolved_acr_rg_name = var.azure_container_resource_group == "" ? local.admin_rg_name : var.azure_container_resource_group
+  resolved_acr_rg_name = var.azure_container_resource_group == "" ? azurerm_resource_group.svcplan.name : var.azure_container_resource_group
   resolved_acr_name    = var.azure_container_resource_name == "" ? local.acr_name : var.azure_container_resource_name
 }
 

--- a/infra/templates/az-service-single-region/commons.tf
+++ b/infra/templates/az-service-single-region/commons.tf
@@ -2,14 +2,26 @@ module "provider" {
   source = "../../modules/providers/azure/provider"
 }
 
+resource "random_string" "workspace_scope" {
+  keepers = {
+    # Generate a new id each time we switch to a new workspace or app id
+    ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+    app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  }
+
+  length = max(1, var.randomization_level) // error for zero-length
+  special = false
+  upper = false
+}
+
 locals {
   // sanitize names
-  app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  app_id  = random_string.workspace_scope.keepers.app_id
   region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
-  ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+  ws_name = random_string.workspace_scope.keepers.ws_name
 
   // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
-  base_name     = "${local.app_id}-${local.ws_name}"
+  base_name     = "${local.app_id}-${local.ws_name}%{ if var.randomization_level > 0 }-${random_string.workspace_scope.result}%{ endif }"
   base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
   base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
   base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"

--- a/infra/templates/az-service-single-region/commons.tf
+++ b/infra/templates/az-service-single-region/commons.tf
@@ -1,0 +1,33 @@
+module "provider" {
+  source = "../../modules/providers/azure/provider"
+}
+
+locals {
+  // sanitize names
+  app_id  = replace(trimspace(lower(var.name)), "_", "-")
+  region = replace(trimspace(lower(var.resource_group_location)), "_", "-")
+  ws_name = replace(trimspace(lower(terraform.workspace)), "_", "-")
+
+  // base name for resources, name constraints documented here: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions
+  base_name     = "${local.app_id}-${local.ws_name}"
+  base_name_21  = length(local.base_name) < 22 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 10)}-${substr(replace(local.ws_name, "-", ""), 0, 10)}"
+  base_name_46  = length(local.base_name) < 47 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 25)}-${substr(replace(local.ws_name, "-", ""), 0, 20)}"
+  base_name_60  = length(local.base_name) < 61 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 34)}-${substr(replace(local.ws_name, "-", ""), 0, 25)}"
+  base_name_76  = length(local.base_name) < 77 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 45)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+  base_name_83  = length(local.base_name) < 84 ? local.base_name : "${substr(replace(local.app_id, "-", ""), 0, 52)}-${substr(replace(local.ws_name, "-", ""), 0, 30)}"
+
+  // Resource names
+  admin_rg_name    = "${local.base_name_83}-adm-rg"               // resource group used for admin resources (max 90 chars)
+  app_rg_name      = "${local.base_name_83}-app-rg"               // app resource group (max 90 chars)
+  sp_name          = "${local.base_name}-sp"                      // service plan
+  ai_name          = "${local.base_name}-ai"                      // app insights
+  kv_name          = "${local.base_name_21}-kv"                   // key vault (max 24 chars)
+  acr_name         = "${replace(local.base_name_46, "-", "")}acr" // container registry (max 50 chars, alphanumeric *only*)
+  vnet_name        = "${local.base_name_60}-net"                  // virtual network (max 64 chars)
+  tm_profile_name  = "${local.base_name_60}-tf"                   // traffic manager profile (max 63 chars)
+  tm_endpoint_name = "${local.region}_${local.app_id}"            // traffic manager endpoint
+  tm_dns_name      = "${local.base_name}-dns"                     // traffic manager dns relative name
+  appgateway_name  = "${local.base_name_76}-gw"                   // app gateway (max 80 chars)
+  public_pip_name  = "${local.base_name_76}-ip"                   // public IP (max 80 chars)
+}
+

--- a/infra/templates/az-service-single-region/terraform.tfvars
+++ b/infra/templates/az-service-single-region/terraform.tfvars
@@ -4,10 +4,12 @@
 #
 # Note: These values will impact the names of resources. If your deployment
 # fails due to a resource name collision, consider using different values for
-# the `name` variable.
+# the `name` variable or increasing the value for `randomization_level`.
 
 resource_group_location = "eastus"
 name                    = "az-simple"
+randomization_level     = 8
+
 deployment_targets = [{
   app_name                 = "cobalt-backend-api",
   image_name               = "msftcse/az-service-single-region",

--- a/infra/templates/az-service-single-region/terraform.tfvars
+++ b/infra/templates/az-service-single-region/terraform.tfvars
@@ -3,7 +3,7 @@
 # responsibility to choose the values that make sense for your application.
 #
 # Note: These values will impact the names of resources. If your deployment
-# fails due to a resource name colision, consider using different values for
+# fails due to a resource name collision, consider using different values for
 # the `name` variable.
 
 resource_group_location = "eastus"

--- a/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
+++ b/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
@@ -35,7 +35,6 @@ func asMap(t *testing.T, jsonString string) map[string]interface{} {
 
 func TestTemplate(t *testing.T) {
 	expectedAppServicePlan := asMap(t, `{
-		"name":        "cobalt-backend-api-`+workspace+`"
 	}`)
 
 	expectedAppGatewayPlan := asMap(t, `{
@@ -101,14 +100,9 @@ func TestTemplate(t *testing.T) {
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{
 			"azurerm_resource_group.svcplan": map[string]interface{}{
 				"location": region,
-				"name":     "az-simple-" + workspace,
 			},
-			"module.app_gateway.data.azurerm_resource_group.appgateway": map[string]interface{}{
-				"name": "az-simple-" + workspace,
-			},
-			"module.app_insight.data.azurerm_resource_group.appinsights": map[string]interface{}{
-				"name": "az-simple-" + workspace,
-			},
+			"module.app_gateway.data.azurerm_resource_group.appgateway":  map[string]interface{}{},
+			"module.app_insight.data.azurerm_resource_group.appinsights": map[string]interface{}{},
 			"module.app_service.azurerm_app_service_slot.appsvc_staging_slot[0]": map[string]interface{}{
 				"name": "staging",
 			},

--- a/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
+++ b/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
@@ -97,7 +97,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:             tfOptions,
 		Workspace:             workspace,
 		PlanAssertions:        nil,
-		ExpectedResourceCount: 35,
+		ExpectedResourceCount: 36,
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{
 			"azurerm_resource_group.svcplan": map[string]interface{}{
 				"location": region,

--- a/infra/templates/az-service-single-region/variables.tf
+++ b/infra/templates/az-service-single-region/variables.tf
@@ -1,22 +1,33 @@
-# Resource Group
-variable "resource_group_location" {
-  description = "The deployment location of resource group container all the resources"
+// ---- General Configuration ----
+
+variable "name" {
+  description = "An identifier used to construct the names of all resources in this template."
   type        = string
 }
+
+variable "resource_group_location" {
+  description = "The Azure region where all resources in this template should be created."
+  type        = string
+}
+
+
+
+// ---- App Service Configuration ----
 
 variable "application_type" {
   description = "Type of the App Insights Application.  Valid values are ios for iOS, java for Java web, MobileCenter for App Center, Node.JS for Node.js, other for General, phone for Windows Phone, store for Windows Store and web for ASP.NET."
   default     = "Web"
 }
 
-variable "name" {
-  description = "The name of the deployment.  This will be used across the resource created in this solution"
-  type        = string
-}
-
 variable "acr_build_git_source_url" {
   description = "The URL to a git repository (e.g., 'https://github.com/Azure-Samples/acr-build-helloworld-node.git') containing the docker build manifests."
   type        = string
+}
+
+variable "acr_build_docker_file" {
+  description = "The relative path of the the docker file to the source code root folder. Default to 'Dockerfile'."
+  type        = string
+  default     = "Dockerfile"
 }
 
 variable "deployment_targets" {
@@ -67,7 +78,9 @@ variable "subnet_prefixes" {
   default     = ["10.0.1.0/24"]
 }
 
-# Monitoring Service
+
+// ---- Monitoring Service Configuration ----
+
 variable "action_group_name" {
   description = "The name of the action group."
   type        = string
@@ -132,10 +145,4 @@ variable "monitoring_dimension_values" {
   description = "Dimensions used to determine service plan scaling."
   type        = list(string)
   default     = ["*"]
-}
-
-variable "acr_build_docker_file" {
-  description = "The relative path of the the docker file to the source code root folder. Default to 'Dockerfile'."
-  type        = string
-  default     = "Dockerfile"
 }

--- a/infra/templates/az-service-single-region/variables.tf
+++ b/infra/templates/az-service-single-region/variables.tf
@@ -5,6 +5,12 @@ variable "name" {
   type        = string
 }
 
+variable "randomization_level" {
+  description = "Number of additional random characters to include in resource names to insulate against unexpected resource name collisions."
+  type        = number
+  default     = 8
+}
+
 variable "resource_group_location" {
   description = "The Azure region where all resources in this template should be created."
   type        = string


### PR DESCRIPTION
Resolve issues and concerns with resource naming strategy and naming collisions


## All Submissions:
-------------------------------------
* [X] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes. (*see below*)
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran lint checks locally prior to submission.
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
Resource names generated during template processing are not always consistent or unique, leading to unintended consequences such as name conflicts. This also prevents key scenarios such as isolation of concurrent template pipelines.

Issue Number: #254


## What is the new behavior?
-------------------------------------
Resource naming has been overhauled:
- All names are pre-calculated in the locals block of a `commons.tf` template file, for consistency and to ease maintenance/debugging
- Any instances of name generation within reusable modules has been elevated to the pre-calculation locals block
- All names use the same basename pattern to compute a unique prefix
- Support for "shortened" versions of names is added, for resource types that have a limited number of characters
- Support for (optional) insertion of a random sequence of characters into the resource names, to further protect against name collisions

## Does this introduce a breaking change?
-------------------------------------
- [X] Some module and/or template variable names have been changed or introduced:
  - `prefix` is renamed to `name` in Hello World template
  - `uses_acr` introduced to app-service module
  - `uses_vnet` introduced to app-service module
  - `app_service_name_prefix` introduced to app-service module
  - `randomization_level` introduced to all three templates

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
-------------------------------------
No new tests were added, but due to the nature of how the randomization vector affects the determinism of resource names, any tests that validate the names needed to be disabled/removed. Resource names can no longer be known during PLAN stage, so they cannot be verified using the unit tests.
