### PR TITLE
Added Key Vault access policies for App Service identities in az-isolated-service-single-region template

### DIFF
--- a/infra/templates/az-isolated-service-single-region/ase.tf
+++ b/infra/templates/az-isolated-service-single-region/ase.tf
@@ -70,6 +70,17 @@ module "app_service" {
   }
 }
 
+module "app_service_keyvault_access_policy" {
+  source                  = "../../modules/providers/azure/keyvault-policy"
+  instance_count          = length(var.unauthn_deployment_targets)
+  vault_id                = module.keyvault.keyvault_id
+  tenant_id               = module.app_service.app_service_identity_tenant_id
+  object_ids              = module.app_service.app_service_identity_object_ids
+  key_permissions         = ["get", "list"]
+  secret_permissions      = ["get", "list"]
+  certificate_permissions = ["get", "list"]
+}
+
 module "authn_app_service" {
   source                           = "../../modules/providers/azure/app-service"
   service_plan_name                = module.service_plan.service_plan_name
@@ -88,6 +99,17 @@ module "authn_app_service" {
   providers = {
     "azurerm" = "azurerm.admin"
   }
+}
+
+module "authn_app_service_keyvault_access_policy" {
+  source                  = "../../modules/providers/azure/keyvault-policy"
+  instance_count          = length(var.authn_deployment_targets)
+  vault_id                = module.keyvault.keyvault_id
+  tenant_id               = module.authn_app_service.app_service_identity_tenant_id
+  object_ids              = module.authn_app_service.app_service_identity_object_ids
+  key_permissions         = ["get", "list"]
+  secret_permissions      = ["get", "list"]
+  certificate_permissions = ["get", "list"]
 }
 
 module "ad_application" {

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -6,6 +6,7 @@
 # fails due to a resource name colision, consider using different values for
 # the `name` variable.
 
+# Targets that will be configured to also setup AuthN with Easy Auth
 authn_deployment_targets = [
   {
     app_name                 = "co-frontend-api-1",
@@ -16,6 +17,7 @@ authn_deployment_targets = [
   }
 ]
 
+# Targets that will not have any AuthN configured
 unauthn_deployment_targets = [
   {
     app_name                 = "co-backend-api-1",

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -224,7 +224,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:             tfOptions,
 		Workspace:             workspace,
 		PlanAssertions:        nil,
-		ExpectedResourceCount: 49,
+		ExpectedResourceCount: 51,
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{
 			"azurerm_resource_group.app_rg":   expectedAppDevResourceGroup,
 			"azurerm_resource_group.admin_rg": expectedAdminResourceGroup,


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [x] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
The `az-isolated-service-single-region` template creates all app services in Azure with system assigned identities; however, the Key Vault does not have an access policy for those identities to allow them Get/List permissions to the resource objects.

Issue Number: #282 


## What is the new behavior?
-------------------------------------
- [x] App services defined within the unauthn_deployment_targets will also have a key vault access policy created providing them with GET/LIST permissions
- [x] App services defined within the authn_deployment_targets will also have a key vault access policy created providing them with GET/LIST permissions

## Does this introduce a breaking change?
-------------------------------------
- [NO]

While the behavior will be different, it should only add the permission to any existing deployments.

## Any relevant logs, error output, etc?
-------------------------------------
N/A

## Other information
-------------------------------------
N/A