### PR TITLE
Altered pipeline jobs to respect AGENT_POOL

### DIFF
--- a/devops/providers/azure-devops/templates/azure-pipelines.yml
+++ b/devops/providers/azure-devops/templates/azure-pipelines.yml
@@ -38,17 +38,17 @@ stages:
     configurationMatrix:
     - jobName: az_hello_world
       terraformTemplatePath: 'infra/templates/az-hello-world'
-      terraformWorkspacePrefix: '288hw'
+      terraformWorkspacePrefix: 'hw'
       environmentsToTeardownAfterRelease:
       - 'devint'
 
     - jobName: az_service_single_region
       terraformTemplatePath: 'infra/templates/az-service-single-region'
-      terraformWorkspacePrefix: '288sr'
+      terraformWorkspacePrefix: 'sr'
       environmentsToTeardownAfterRelease:
       - 'devint'
 
     - jobName: az_isolated_service_single_region
       terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
-      terraformWorkspacePrefix: '288iso'
+      terraformWorkspacePrefix: 'iso'
       deploymentTimeoutInMinutes: 120

--- a/devops/providers/azure-devops/templates/azure-pipelines.yml
+++ b/devops/providers/azure-devops/templates/azure-pipelines.yml
@@ -38,17 +38,17 @@ stages:
     configurationMatrix:
     - jobName: az_hello_world
       terraformTemplatePath: 'infra/templates/az-hello-world'
-      terraformWorkspacePrefix: 'hw'
+      terraformWorkspacePrefix: '288hw'
       environmentsToTeardownAfterRelease:
       - 'devint'
 
     - jobName: az_service_single_region
       terraformTemplatePath: 'infra/templates/az-service-single-region'
-      terraformWorkspacePrefix: 'sr'
+      terraformWorkspacePrefix: '288sr'
       environmentsToTeardownAfterRelease:
       - 'devint'
 
     - jobName: az_isolated_service_single_region
       terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
-      terraformWorkspacePrefix: 'iso'
+      terraformWorkspacePrefix: '288iso'
       deploymentTimeoutInMinutes: 120

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-build-stage.yml
@@ -6,6 +6,7 @@ jobs:
 
 - job: TemplateChangeDetection
   displayName: Determine CI Targets to Run
+  pool: $(AGENT_POOL)
   steps:
   - ${{ each config in parameters.configurationMatrix }}:
     - task: Bash@3

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
@@ -21,12 +21,11 @@ jobs:
 - ${{ each config in parameters.configurationMatrix }}:
   - deployment: Provision_${{ config.jobName }}_${{ parameters.environment }}
     dependsOn: TemplateChangeDetection
+    pool: $(AGENT_POOL)
     condition: eq(dependencies.TemplateChangeDetection.outputs['${{ config.jobName }}.needs_cicd'], 'true')
 
     ${{ if config.deploymentTimeoutInMinutes }}:
       timeoutInMinutes: '${{ config.deploymentTimeoutInMinutes }}'
-
-  pool: $(AGENT_POOL)
 
     variables:
     - group: '${{ parameters.environment }} Environment Variables'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
@@ -26,8 +26,7 @@ jobs:
     ${{ if config.deploymentTimeoutInMinutes }}:
       timeoutInMinutes: '${{ config.deploymentTimeoutInMinutes }}'
 
-    pool:
-      vmImage: $(AGENT_POOL)
+  pool: $(AGENT_POOL)
 
     variables:
     - group: '${{ parameters.environment }} Environment Variables'

--- a/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
+++ b/devops/providers/azure-devops/templates/infrastructure/azure-pipeline-release-stage.yml
@@ -5,6 +5,7 @@ parameters:
 jobs:
 
 - job: TemplateChangeDetection
+  pool: $(AGENT_POOL)
   displayName: Determine CD Targets to Run
   steps:
   - ${{ each config in parameters.configurationMatrix }}:

--- a/infra/modules/providers/azure/provider/main.tf
+++ b/infra/modules/providers/azure/provider/main.tf
@@ -9,4 +9,3 @@ provider "null" {
 provider "azuread" {
   version = "~>0.4.0"
 }
-


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES/NO] I have updated the documentation accordingly.
* [YES/NO/NA] I have added tests to cover my changes.
* [YES/NO/NA] All new and existing tests passed.
* [YES/NO/NA] My code follows the code style of this project.
* [YES/NO/NA] I ran lint checks locally prior to submission.
* [YES/NO] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
Several pipeline jobs were not respecting `AGENT_POOL`, thus preventing use of self-hosted build agents.

Issue Number: 288


## What is the new behavior?
-------------------------------------
Pipeline jobs are now respecting `AGENT_POOL`.

## Does this introduce a breaking change?
-------------------------------------
- [NO] however...

It's possible that use of some agent pools will lead to concurrent jobs. It's important that jobs & templates be written in a way that supports concurrency.

## Any relevant logs, error output, etc?
-------------------------------------
n/a


## Other information
-------------------------------------
n/a
