### PR TITLE
Add new diagnostic flag to force CI/CD loops

### DIFF
--- a/devops/providers/azure-devops/templates/azure-pipelines.yml
+++ b/devops/providers/azure-devops/templates/azure-pipelines.yml
@@ -2,53 +2,53 @@ trigger:
   batch: true
   branches:
     include:
-      - master
+    - master
   paths:
     include:
-      - /infra/modules/*
-      - /infra/templates/*
-      - /test/*
+    - /infra/modules/*
+    - /infra/templates/*
+    - /test/*
     exclude:
-      - devops/*
-      - design-reference/*
-      - /**/*.md
-      - /test/docker/*
+    - devops/*
+    - design-reference/*
+    - /**/*.md
+    - /test/docker/*
 pr:
   autoCancel: false
   branches:
     include:
-      - master
+    - master
   paths:
     include:
-      - /infra/modules/*
-      - /infra/templates/*
-      - /test/*
+    - /infra/modules/*
+    - /infra/templates/*
+    - /test/*
     exclude:
-      - devops/*
-      - design-reference/*
-      - /**/*.md
-      - /test/docker/*
+    - devops/*
+    - design-reference/*
+    - /**/*.md
+    - /test/docker/*
 
 stages:
-  - template: ./infrastructure/azure-pipeline-cicd-compose.yml
-    parameters:
-      environments:
-        - 'devint'
+- template: ./infrastructure/azure-pipeline-cicd-compose.yml
+  parameters:
+    environments:
+    - 'devint'
 
-      configurationMatrix:
-        - jobName: az_hello_world
-          terraformTemplatePath: 'infra/templates/az-hello-world'
-          terraformWorkspacePrefix: 'hw'
-          environmentsToTeardownAfterRelease:
-            - 'devint'
+    configurationMatrix:
+    - jobName: az_hello_world
+      terraformTemplatePath: 'infra/templates/az-hello-world'
+      terraformWorkspacePrefix: 'hw'
+      environmentsToTeardownAfterRelease:
+      - 'devint'
 
-        - jobName: az_service_single_region
-          terraformTemplatePath: 'infra/templates/az-service-single-region'
-          terraformWorkspacePrefix: 'sr'
-          environmentsToTeardownAfterRelease:
-            - 'devint'
+    - jobName: az_service_single_region
+      terraformTemplatePath: 'infra/templates/az-service-single-region'
+      terraformWorkspacePrefix: 'sr'
+      environmentsToTeardownAfterRelease:
+      - 'devint'
 
-        - jobName: az_isolated_service_single_region
-          terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
-          terraformWorkspacePrefix: 'iso'
-          deploymentTimeoutInMinutes: 120
+    - jobName: az_isolated_service_single_region
+      terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
+      terraformWorkspacePrefix: 'iso'
+      deploymentTimeoutInMinutes: 120

--- a/devops/providers/azure-devops/templates/azure-pipelines.yml
+++ b/devops/providers/azure-devops/templates/azure-pipelines.yml
@@ -38,17 +38,17 @@ stages:
     configurationMatrix:
     - jobName: az_hello_world
       terraformTemplatePath: 'infra/templates/az-hello-world'
-      terraformWorkspacePrefix: 'hw'
+      terraformWorkspacePrefix: '270hw'
       environmentsToTeardownAfterRelease:
       - 'devint'
 
     - jobName: az_service_single_region
       terraformTemplatePath: 'infra/templates/az-service-single-region'
-      terraformWorkspacePrefix: 'sr'
+      terraformWorkspacePrefix: '270sr'
       environmentsToTeardownAfterRelease:
       - 'devint'
 
     - jobName: az_isolated_service_single_region
       terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
-      terraformWorkspacePrefix: 'iso'
+      terraformWorkspacePrefix: '270iso'
       deploymentTimeoutInMinutes: 120

--- a/devops/providers/azure-devops/templates/azure-pipelines.yml
+++ b/devops/providers/azure-devops/templates/azure-pipelines.yml
@@ -2,53 +2,53 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+      - master
   paths:
     include:
-    - /infra/modules/*
-    - /infra/templates/*
-    - /test/*
+      - /infra/modules/*
+      - /infra/templates/*
+      - /test/*
     exclude:
-    - devops/*
-    - design-reference/*
-    - /**/*.md
-    - /test/docker/*
+      - devops/*
+      - design-reference/*
+      - /**/*.md
+      - /test/docker/*
 pr:
   autoCancel: false
   branches:
     include:
-    - master
+      - master
   paths:
     include:
-    - /infra/modules/*
-    - /infra/templates/*
-    - /test/*
+      - /infra/modules/*
+      - /infra/templates/*
+      - /test/*
     exclude:
-    - devops/*
-    - design-reference/*
-    - /**/*.md
-    - /test/docker/*
+      - devops/*
+      - design-reference/*
+      - /**/*.md
+      - /test/docker/*
 
 stages:
-- template: ./infrastructure/azure-pipeline-cicd-compose.yml
-  parameters:
-    environments:
-    - 'devint'
+  - template: ./infrastructure/azure-pipeline-cicd-compose.yml
+    parameters:
+      environments:
+        - 'devint'
 
-    configurationMatrix:
-    - jobName: az_hello_world
-      terraformTemplatePath: 'infra/templates/az-hello-world'
-      terraformWorkspacePrefix: '270hw'
-      environmentsToTeardownAfterRelease:
-      - 'devint'
+      configurationMatrix:
+        - jobName: az_hello_world
+          terraformTemplatePath: 'infra/templates/az-hello-world'
+          terraformWorkspacePrefix: 'hw'
+          environmentsToTeardownAfterRelease:
+            - 'devint'
 
-    - jobName: az_service_single_region
-      terraformTemplatePath: 'infra/templates/az-service-single-region'
-      terraformWorkspacePrefix: '270sr'
-      environmentsToTeardownAfterRelease:
-      - 'devint'
+        - jobName: az_service_single_region
+          terraformTemplatePath: 'infra/templates/az-service-single-region'
+          terraformWorkspacePrefix: 'sr'
+          environmentsToTeardownAfterRelease:
+            - 'devint'
 
-    - jobName: az_isolated_service_single_region
-      terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
-      terraformWorkspacePrefix: '270iso'
-      deploymentTimeoutInMinutes: 120
+        - jobName: az_isolated_service_single_region
+          terraformTemplatePath: 'infra/templates/az-isolated-service-single-region'
+          terraformWorkspacePrefix: 'iso'
+          deploymentTimeoutInMinutes: 120

--- a/devops/providers/azure-devops/templates/infrastructure/scripts/set-cicd-flag.sh
+++ b/devops/providers/azure-devops/templates/infrastructure/scripts/set-cicd-flag.sh
@@ -9,6 +9,12 @@ function setCICDFlag() {
     echo "##vso[task.setvariable variable=needs_cicd;isOutput=true]true"
 }
 
+if [ ! -z ${FORCE_CICD} ]; then
+  echo "Forcing CI/CD. No changed checks needed."
+  setCICDFlag
+  exit 0
+fi
+
 MASTER="remotes/origin/master"
 GIT_DIFF_SOURCEBRANCH="HEAD"
 


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] I have updated the documentation accordingly.
* [NO] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [NA] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
CI/CD only runs when file of the follow types have been changed: 
`*.go|*.tf|*.sh|Dockerfile*|*.tfvars|*.yaml|*.yml`

Issue Number: Closes #270

## What is the new behavior?
-------------------------------------
When an environment variable named `FORCE_CICD` is present, no file change checks are performed and CI/CD is forced to run.

## Does this introduce a breaking change?
-------------------------------------
- [YES]

## Any relevant logs, error output, etc?
-------------------------------------
Example of a typical message the change will emit into job output:
```
Forcing CI/CD. No changed checks needed.
Template infra/templates/az-hello-world needs CI/CD
```

## Other information
-------------------------------------
This is a very diagnostic feature. I didn't think to alter documentation to include a reference to it, ideally a tips & tricks for ADD PAT developers might want to call attention to this feature. 
