### PR TITLE
Adds dockerfile for docker based azdo build agent

### DIFF
--- a/devops/providers/azure-devops/build-agent/Dockerfile
+++ b/devops/providers/azure-devops/build-agent/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+
+# To make it easier for build and release pipelines to run apt-get,
+# configure apt to not require confirmation (assume the -y argument by default)
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends \
+		apt-transport-https \
+        ca-certificates \
+		gnupg-agent \
+		software-properties-common \
+        curl \
+        jq \
+        git \
+        iputils-ping \
+        libcurl3 \
+        libicu55 \
+        libunwind8 \
+        netcat && \
+	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+	add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable" && \
+	apt-get update && \
+	apt-get install -y docker-ce docker-ce-cli containerd.io && \
+	usermod -aG docker $(whoami)
+
+WORKDIR /azp
+
+COPY ./start.sh .
+RUN chmod +x start.sh
+
+CMD ["./start.sh"]

--- a/devops/providers/azure-devops/build-agent/readme.md
+++ b/devops/providers/azure-devops/build-agent/readme.md
@@ -1,0 +1,14 @@
+# CSE Azure Pipeline Agent
+
+This agent will allow CSE projects to build any linux based project using container tasks.
+
+[Running in Docker](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops#linux)
+
+```bash
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock \
+    -e "AZP_URL=https://dev.azure.com/PROJECT" \
+    -e "AZP_TOKEN=PAT_TOKEN" \
+    -e "AZP_AGENT_NAME=myAgent01" \
+    -e "AZP_POOL=DocPool" \
+    registry/cobalt-agent:0.0.1
+```

--- a/devops/providers/azure-devops/build-agent/start.sh
+++ b/devops/providers/azure-devops/build-agent/start.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$AZP_URL" ]; then
+  echo 1>&2 "error: missing AZP_URL environment variable"
+  exit 1
+fi
+
+if [ -z "$AZP_TOKEN_FILE" ]; then
+  if [ -z "$AZP_TOKEN" ]; then
+    echo 1>&2 "error: missing AZP_TOKEN environment variable"
+    exit 1
+  fi
+
+  AZP_TOKEN_FILE=/azp/.token
+  echo -n $AZP_TOKEN > "$AZP_TOKEN_FILE"
+fi
+
+unset AZP_TOKEN
+
+if [ -n "$AZP_WORK" ]; then
+  mkdir -p "$AZP_WORK"
+fi
+
+rm -rf /azp/agent
+mkdir /azp/agent
+cd /azp/agent
+
+export AGENT_ALLOW_RUNASROOT="1"
+
+cleanup() {
+  if [ -e config.sh ]; then
+    print_header "Cleanup. Removing Azure Pipelines agent..."
+
+    ./config.sh remove --unattended \
+      --auth PAT \
+      --token $(cat "$AZP_TOKEN_FILE")
+  fi
+}
+
+print_header() {
+  lightcyan='\033[1;36m'
+  nocolor='\033[0m'
+  echo -e "${lightcyan}$1${nocolor}"
+}
+
+# Let the agent ignore the token env variables
+export VSO_AGENT_IGNORE=AZP_TOKEN,AZP_TOKEN_FILE
+
+print_header "1. Determining matching Azure Pipelines agent..."
+
+AZP_AGENT_RESPONSE=$(curl -LsS \
+  -u user:$(cat "$AZP_TOKEN_FILE") \
+  -H 'Accept:application/json;api-version=3.0-preview' \
+  "$AZP_URL/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$AZP_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
+  AZP_AGENTPACKAGE_URL=$(echo "$AZP_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+fi
+
+if [ -z "$AZP_AGENTPACKAGE_URL" -o "$AZP_AGENTPACKAGE_URL" == "null" ]; then
+  echo 1>&2 "error: could not determine a matching Azure Pipelines agent - check that account '$AZP_URL' is correct and the token is valid for that account"
+  exit 1
+fi
+
+print_header "2. Downloading and installing Azure Pipelines agent..."
+
+curl -LsS $AZP_AGENTPACKAGE_URL | tar -xz & wait $!
+
+source ./env.sh
+
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+print_header "3. Configuring Azure Pipelines agent..."
+
+./config.sh --unattended \
+  --agent "${AZP_AGENT_NAME:-$(hostname)}" \
+  --url "$AZP_URL" \
+  --auth PAT \
+  --token $(cat "$AZP_TOKEN_FILE") \
+  --pool "${AZP_POOL:-Default}" \
+  --work "${AZP_WORK:-_work}" \
+  --replace \
+  --acceptTeeEula & wait $!
+
+print_header "4. Running Azure Pipelines agent..."
+
+# `exec` the node runtime so it's aware of TERM and INT signals
+# AgentService.js understands how to handle agent self-update and restart
+exec ./externals/node/bin/node ./bin/AgentService.js interactive


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [x] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
Currently, we use hosted build agents only.

Issue Number: #304 


## What is the new behavior?
-------------------------------------
Adds a dockerfile/startup script to allow for dockerized azdo build agents.

## Does this introduce a breaking change?
-------------------------------------
- [x] No


## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
-------------------------------------
To test: 

1. Setup a new pool in AzDO project.
2. Create a PAT.
3. Build docker image: `docker build -t cseagent:0 .`
4. Run `docker run -v /var/run/docker.sock:/var/run/docker.sock -e "AZP_URL=https://dev.azure.com/PROJECT_NAME" -e "AZP_TOKEN=PAT_TOKEN" -e "AZP_AGENT_NAME=CSEAgent01" -e "AZP_POOL=POOL_NAME" cseagent:0`
