### PR TITLE
Remove unused app service variable values 'repository' and 'dockerfile'

### DIFF
--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -14,8 +14,6 @@ randomization_level     = 8
 authn_deployment_targets = [
   {
     app_name                 = "co-frontend-api-1",
-    repository               = "",
-    dockerfile               = "",
     image_name               = "appsvcsample/echo-server-1",
     image_release_tag_prefix = "release"
   }
@@ -25,8 +23,6 @@ authn_deployment_targets = [
 unauthn_deployment_targets = [
   {
     app_name                 = "co-backend-api-1",
-    repository               = "",
-    dockerfile               = "",
     image_name               = "appsvcsample/echo-server-2",
     image_release_tag_prefix = "release"
   }

--- a/infra/templates/az-isolated-service-single-region/tests/integration/integration_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/integration/integration_test.go
@@ -19,8 +19,6 @@ var adminSubscription = os.Getenv("ARM_SUBSCRIPTION_ID")
 var unauthn_deploymentTargets = []map[string]string{
 	map[string]string{
 		"app_name":                 "co-backend-api-1",
-		"repository":               "https://github.com/erikschlegel/echo-server.git",
-		"dockerfile":               "Dockerfile",
 		"image_name":               "appsvcsample/echo-server-2",
 		"image_release_tag_prefix": "release",
 	},
@@ -29,8 +27,6 @@ var unauthn_deploymentTargets = []map[string]string{
 var authn_deploymentTargets = []map[string]string{
 	map[string]string{
 		"app_name":                 "co-frontend-api-1",
-		"repository":               "https://github.com/erikschlegel/echo-server.git",
-		"dockerfile":               "Dockerfile",
 		"image_name":               "appsvcsample/echo-server-1",
 		"image_release_tag_prefix": "release",
 	},

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -210,7 +210,7 @@ func TestTemplate(t *testing.T) {
 		TfOptions:             tfOptions,
 		Workspace:             workspace,
 		PlanAssertions:        nil,
-		ExpectedResourceCount: 60,
+		ExpectedResourceCount: 61,
 		ExpectedResourceAttributeValues: infratests.ResourceDescription{
 			"azurerm_resource_group.app_rg":   expectedAppDevResourceGroup,
 			"azurerm_resource_group.admin_rg": expectedAdminResourceGroup,

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -31,8 +31,6 @@ var tfOptions = &terraform.Options{
 		"authn_deployment_targets": []interface{}{
 			map[string]string{
 				"app_name":                 "co-frontend-api-1",
-				"repository":               "https://github.com/erikschlegel/echo-server.git",
-				"dockerfile":               "Dockerfile",
 				"image_name":               "appsvcsample/echo-server-1",
 				"image_release_tag_prefix": "release",
 			},
@@ -40,8 +38,6 @@ var tfOptions = &terraform.Options{
 		"unauthn_deployment_targets": []interface{}{
 			map[string]string{
 				"app_name":                 "co-backend-api-1",
-				"repository":               "https://github.com/erikschlegel/echo-server.git",
-				"dockerfile":               "Dockerfile",
 				"image_name":               "appsvcsample/echo-server-2",
 				"image_release_tag_prefix": "release",
 			},

--- a/infra/templates/az-isolated-service-single-region/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/variables.tf
@@ -49,8 +49,6 @@ variable "unauthn_deployment_targets" {
   description = "Metadata about apps to deploy, such as repository location, docker file metadata and image names"
   type = list(object({
     app_name                 = string
-    repository               = string
-    dockerfile               = string
     image_name               = string
     image_release_tag_prefix = string
   }))
@@ -60,8 +58,6 @@ variable "authn_deployment_targets" {
   description = "Metadata about apps to deploy that also require authentication."
   type = list(object({
     app_name                 = string
-    repository               = string
-    dockerfile               = string
     image_name               = string
     image_release_tag_prefix = string
   }))


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [x] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [N/A] I have updated the documentation accordingly.
* [N/A] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the `as-isolated-service-single-region` template assigns and expects the fields `repository` and `dockerfile`; however, these are not used by the app services that are created. The result is a confusing addition of required but unused variables.

Issue Number: Closes #209 


## What is the new behavior?
-------------------------------------
Behavior of the deployment does not change; however removal of the unused variables helps clarify usage. 

- [x] Removed https://github.com/microsoft/cobalt/blob/master/infra/templates/az-isolated-service-single-region/variables.tf#L45-L46 so that unused and unnecessary assignments would not be required
- [x] Updated integration and unit tests to remove assignments
- [x] Updated template `.tfvars` to remove assignments

## Does this introduce a breaking change?
-------------------------------------
- [NO] No breaking change -- corrects unnecessary and unused variable assignments

## Any relevant logs, error output, etc?
-------------------------------------
N/A


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
