### PR TITLE
Pass subscription ID to Az CLI commands

### DIFF
--- a/infra/modules/providers/azure/app-gateway/main.tf
+++ b/infra/modules/providers/azure/app-gateway/main.tf
@@ -2,6 +2,8 @@ data "azurerm_resource_group" "appgateway" {
   name = var.resource_group_name
 }
 
+data "azurerm_client_config" "current" {}
+
 locals {
   authentication_certificate_name = "gateway-public-key"
   backend_probe_name              = "probe-1"
@@ -100,6 +102,13 @@ resource "azurerm_application_gateway" "appgateway" {
 data "external" "app_gw_health" {
   depends_on = [azurerm_application_gateway.appgateway]
 
-  program = ["az", "network", "application-gateway", "show-backend-health", "-g", data.azurerm_resource_group.appgateway.name, "-n", var.appgateway_name, "-o", "json", "--query", "backendAddressPools[0].backendHttpSettingsCollection[0].servers[0].{address:address,health:health}"]
+  program = [
+    "az", "network", "application-gateway", "show-backend-health",
+    "--subscription", data.azurerm_client_config.current.subscription_id,
+    "--resource-group", data.azurerm_resource_group.appgateway.name,
+    "--name", var.appgateway_name,
+    "--output", "json",
+    "--query", "backendAddressPools[0].backendHttpSettingsCollection[0].servers[0].{address:address,health:health}"
+  ]
 }
 

--- a/infra/modules/providers/azure/keyvault-cert/main.tf
+++ b/infra/modules/providers/azure/keyvault-cert/main.tf
@@ -95,7 +95,14 @@ data "external" "public_cert" {
     azurerm_key_vault_certificate.kv_cert_import,
   ]
 
-  program = ["az", "keyvault", "certificate", "show", "--name", var.key_vault_cert_name, "--vault-name", var.keyvault_name, "-o", "json", "--query", "{cer:cer}"]
+  program = [
+    "az", "keyvault", "certificate", "show",
+    "--name", var.key_vault_cert_name,
+    "--subscription", data.azurerm_client_config.current.subscription_id,
+    "--vault-name", var.keyvault_name,
+    "--output", "json",
+    "--query", "{cer:cer}"
+  ]
 }
 
 data "external" "private_pfx" {
@@ -104,6 +111,13 @@ data "external" "private_pfx" {
     azurerm_key_vault_certificate.kv_cert_import,
   ]
 
-  program = ["az", "keyvault", "secret", "show", "--name", var.key_vault_cert_name, "--vault-name", var.keyvault_name, "-o", "json", "--query", "{value:value}"]
+  program = [
+    "az", "keyvault", "secret", "show",
+    "--name", var.key_vault_cert_name,
+    "--subscription", data.azurerm_client_config.current.subscription_id,
+    "--vault-name", var.keyvault_name,
+    "--output", "json",
+    "--query", "{value:value}"
+  ]
 }
 

--- a/infra/templates/az-isolated-service-single-region/ase.tf
+++ b/infra/templates/az-isolated-service-single-region/ase.tf
@@ -145,13 +145,23 @@ resource "null_resource" "auth" {
   }
 
   provisioner "local-exec" {
-    command = "az webapp auth update -g \"$RES_GRP\" -n \"$APPNAME\" --enabled true --action LoginWithAzureActiveDirectory --aad-token-issuer-url \"$ISSUER\" --aad-client-id \"$APPID\""
+    command = <<EOF
+      az webapp auth update                     \
+        --subscription "$SUBSCRIPTION_ID"       \
+        --resource-group "$RESOURCE_GROUP_NAME" \
+        --name "$APPNAME"                       \
+        --enabled true                          \
+        --action LoginWithAzureActiveDirectory  \
+        --aad-token-issuer-url "$ISSUER"        \
+        --aad-client-id "$APPID"
+      EOF
 
     environment = {
-      RES_GRP = azurerm_resource_group.admin_rg.name
+      SUBSCRIPTION_ID = data.azurerm_client_config.current.subscription_id
+      RESOURCE_GROUP_NAME = azurerm_resource_group.admin_rg.name
       APPNAME = module.authn_app_service.app_service_config_data[count.index].name
-      ISSUER  = format("https://sts.windows.net/%s", local.tenant_id)
-      APPID   = module.ad_application.azuread_config_data[format("%s-%s", module.authn_app_service.app_service_config_data[count.index].name, var.auth_suffix)].application_id
+      ISSUER = format("https://sts.windows.net/%s", local.tenant_id)
+      APPID = module.ad_application.azuread_config_data[format("%s-%s", module.authn_app_service.app_service_config_data[count.index].name, var.auth_suffix)].application_id
     }
   }
 }

--- a/infra/templates/az-service-single-region/appdev.tf
+++ b/infra/templates/az-service-single-region/appdev.tf
@@ -82,9 +82,9 @@ module "app_insight" {
 }
 
 module "keyvault_appsvc_policy" {
-  source     = "../../modules/providers/azure/keyvault-policy"
-  vault_id   = module.keyvault_certificate.vault_id
-  tenant_id  = module.app_service.app_service_identity_tenant_id
+  source = "../../modules/providers/azure/keyvault-policy"
+  vault_id = module.keyvault_certificate.vault_id
+  tenant_id = module.app_service.app_service_identity_tenant_id
   object_ids = module.app_service.app_service_identity_object_ids
 }
 

--- a/infra/templates/az-service-single-region/appdev.tf
+++ b/infra/templates/az-service-single-region/appdev.tf
@@ -4,6 +4,8 @@ data "azurerm_container_registry" "acr" {
   depends_on          = ["azurerm_resource_group.svcplan", "module.container_registry"]
 }
 
+data "azurerm_client_config" "current" {}
+
 # Build and push the app service image slot to enable continuous deployment scenarios. We're using ACR build tasks to remotely carry the docker build / push.
 resource "null_resource" "acr_image_deploy" {
   count      = length(var.deployment_targets)
@@ -14,40 +16,49 @@ resource "null_resource" "acr_image_deploy" {
   }
 
   provisioner "local-exec" {
-    command = "az acr build -t $IMAGE:$TAG -r $REGISTRY -f $DOCKERFILE $SOURCE"
+    command = <<EOF
+      az acr build                              \
+        --subscription "$SUBSCRIPTION_ID"       \
+        --resource-group "$RESOURCE_GROUP_NAME" \
+        -t $IMAGE:$TAG                          \
+        -r $REGISTRY                            \
+        -f $DOCKERFILE $SOURCE
+      EOF
 
     environment = {
-      IMAGE      = var.deployment_targets[count.index].image_name
-      TAG        = var.deployment_targets[count.index].image_release_tag_prefix
-      REGISTRY   = module.container_registry.container_registry_name
+      SUBSCRIPTION_ID = data.azurerm_client_config.current.subscription_id
+      RESOURCE_GROUP_NAME = local.resolved_acr_rg_name
+      IMAGE = var.deployment_targets[count.index].image_name
+      TAG = var.deployment_targets[count.index].image_release_tag_prefix
+      REGISTRY = module.container_registry.container_registry_name
       DOCKERFILE = var.acr_build_docker_file
-      SOURCE     = var.acr_build_git_source_url
+      SOURCE = var.acr_build_git_source_url
     }
 
   }
 }
 
 module "service_plan" {
-  source              = "../../modules/providers/azure/service-plan"
+  source = "../../modules/providers/azure/service-plan"
   resource_group_name = azurerm_resource_group.svcplan.name
-  service_plan_name   = local.sp_name
+  service_plan_name = local.sp_name
 }
 
 module "app_service" {
-  source                           = "../../modules/providers/azure/app-service"
-  app_service_name_prefix          = local.app_svc_name_prefix
-  service_plan_name                = module.service_plan.service_plan_name
+  source = "../../modules/providers/azure/app-service"
+  app_service_name_prefix = local.app_svc_name_prefix
+  service_plan_name = module.service_plan.service_plan_name
   service_plan_resource_group_name = azurerm_resource_group.svcplan.name
   app_insights_instrumentation_key = module.app_insight.app_insights_instrumentation_key
-  uses_acr                         = true
-  azure_container_registry_name    = module.container_registry.container_registry_name
-  docker_registry_server_url       = module.container_registry.container_registry_login_server
-  docker_registry_server_username  = data.azurerm_container_registry.acr.admin_username
-  docker_registry_server_password  = data.azurerm_container_registry.acr.admin_password
-  uses_vnet                        = true
-  vnet_name                        = module.vnet.vnet_name
-  vnet_subnet_id                   = module.vnet.vnet_subnet_ids[0]
-  vault_uri                        = module.keyvault.keyvault_uri
+  uses_acr = true
+  azure_container_registry_name = module.container_registry.container_registry_name
+  docker_registry_server_url = module.container_registry.container_registry_login_server
+  docker_registry_server_username = data.azurerm_container_registry.acr.admin_username
+  docker_registry_server_password = data.azurerm_container_registry.acr.admin_password
+  uses_vnet = true
+  vnet_name = module.vnet.vnet_name
+  vnet_subnet_id = module.vnet.vnet_subnet_ids[0]
+  vault_uri = module.keyvault.keyvault_uri
   app_service_config = {
     for target in var.deployment_targets :
     target.app_name => {
@@ -57,17 +68,17 @@ module "app_service" {
 }
 
 resource "azurerm_role_assignment" "acr_pull" {
-  count                = length(var.deployment_targets)
-  scope                = module.container_registry.container_registry_id
+  count = length(var.deployment_targets)
+  scope = module.container_registry.container_registry_id
   role_definition_name = "AcrPull"
-  principal_id         = module.app_service.app_service_identity_object_ids[count.index]
+  principal_id = module.app_service.app_service_identity_object_ids[count.index]
 }
 
 module "app_insight" {
-  source                           = "../../modules/providers/azure/app-insights"
+  source = "../../modules/providers/azure/app-insights"
   service_plan_resource_group_name = azurerm_resource_group.svcplan.name
-  appinsights_name                 = local.ai_name
-  appinsights_application_type     = var.application_type
+  appinsights_name = local.ai_name
+  appinsights_application_type = var.application_type
 }
 
 module "keyvault_appsvc_policy" {
@@ -78,18 +89,18 @@ module "keyvault_appsvc_policy" {
 }
 
 module "app_monitoring" {
-  source                            = "../../modules/providers/azure/app-monitoring"
-  resource_group_name               = azurerm_resource_group.svcplan.name
-  resource_ids                      = [module.service_plan.app_service_plan_id]
-  action_group_name                 = var.action_group_name
-  action_group_email_receiver       = var.action_group_email_receiver
-  metric_alert_name                 = var.metric_alert_name
-  metric_alert_frequency            = var.metric_alert_frequency
-  metric_alert_period               = var.metric_alert_period
-  metric_alert_criteria_namespace   = var.metric_alert_criteria_namespace
-  metric_alert_criteria_name        = var.metric_alert_criteria_name
+  source = "../../modules/providers/azure/app-monitoring"
+  resource_group_name = azurerm_resource_group.svcplan.name
+  resource_ids = [module.service_plan.app_service_plan_id]
+  action_group_name = var.action_group_name
+  action_group_email_receiver = var.action_group_email_receiver
+  metric_alert_name = var.metric_alert_name
+  metric_alert_frequency = var.metric_alert_frequency
+  metric_alert_period = var.metric_alert_period
+  metric_alert_criteria_namespace = var.metric_alert_criteria_namespace
+  metric_alert_criteria_name = var.metric_alert_criteria_name
   metric_alert_criteria_aggregation = var.metric_alert_criteria_aggregation
-  metric_alert_criteria_operator    = var.metric_alert_criteria_operator
-  metric_alert_criteria_threshold   = var.metric_alert_criteria_threshold
-  monitoring_dimension_values       = var.monitoring_dimension_values
+  metric_alert_criteria_operator = var.metric_alert_criteria_operator
+  metric_alert_criteria_threshold = var.metric_alert_criteria_threshold
+  monitoring_dimension_values = var.monitoring_dimension_values
 }


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
Some Azure CLI commands allow for default parameter values for Subscription ID, Resource Group Name, etc. Cobalt is currently not explicitly setting these parameters when the Terraform modules shell out to run direct Az commands. This does not seem to be causing problems on the current build servers (yet) but does have potential for build unpredictability as those parameters will fall back to configurable defaults from the context of the logged-in user.

Issue Number: #290 

## What is the new behavior?
-------------------------------------
Calls to the Azure CLI now explicitly pass the Subscription ID and Resource Group.

## Does this introduce a breaking change?
-------------------------------------
- [NO]

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
