### PR TITLE
ISO template users can optionally provide a `TF_VAR_resource_ip_whitelist` env-var to control the VNET white-list

### DIFF
--- a/infra/templates/az-isolated-service-single-region/app.tf
+++ b/infra/templates/az-isolated-service-single-region/app.tf
@@ -35,12 +35,17 @@ data "external" "ase_subnets" {
   ]
 }
 
+module "resource_ip_wl_helper" {
+  source            = "./helper-ips"
+  comma_sep_ip_list = var.resource_ip_whitelist
+}
+
 module "keyvault" {
   source                = "../../modules/providers/azure/keyvault"
   keyvault_name         = local.kv_name
   resource_group_name   = azurerm_resource_group.app_rg.name
   subnet_id_whitelist   = values(data.external.ase_subnets.result)
-  resource_ip_whitelist = var.resource_ip_whitelist
+  resource_ip_whitelist = module.resource_ip_wl_helper.ips_as_list
   providers = {
     "azurerm" = "azurerm.app_dev"
   }
@@ -55,7 +60,7 @@ module "container_registry" {
   // Note: only premium ACRs allow configuration of network access restrictions
   container_registry_sku = "Premium"
   subnet_id_whitelist    = values(data.external.ase_subnets.result)
-  resource_ip_whitelist  = var.resource_ip_whitelist
+  resource_ip_whitelist  = module.resource_ip_wl_helper.ips_as_list
   providers = {
     "azurerm" = "azurerm.app_dev"
   }

--- a/infra/templates/az-isolated-service-single-region/docs/design.md
+++ b/infra/templates/az-isolated-service-single-region/docs/design.md
@@ -120,7 +120,7 @@ App Dev Subscription and Networking
 | name | type | default | description |
 |---|---|---|---|
 | `App Dev Subscription` | string |  | Subscription in which the application dependencies will be deployed to |
-| `resource_ip_whitelist` | list[string] |  | A list of IPs and/or IP ranges that should have access to VNET isolated resources provisioned by this template |
+| `resource_ip_whitelist` | string |  | A comma-separated list of IPs and/or IP ranges that should have access to VNET isolated resources provisioned by this template |
 
 **Notes**
 

--- a/infra/templates/az-isolated-service-single-region/helper-ips/main.tf
+++ b/infra/templates/az-isolated-service-single-region/helper-ips/main.tf
@@ -1,0 +1,5 @@
+locals {
+  split_list   = split(",", var.comma_sep_ip_list)
+  trimmed_list = [for ip in local.split_list : trimspace(ip)]
+  ips_as_list  = compact(concat(local.trimmed_list, var.tail_list))
+}

--- a/infra/templates/az-isolated-service-single-region/helper-ips/output.tf
+++ b/infra/templates/az-isolated-service-single-region/helper-ips/output.tf
@@ -1,0 +1,4 @@
+output "ips_as_list" {
+  description = "A list of IP addreses, as a TF List of Strings"
+  value       = local.ips_as_list
+}

--- a/infra/templates/az-isolated-service-single-region/helper-ips/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/helper-ips/tests/unit/unit_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoesNotRequireTailList(t *testing.T) {
+	expectedList := []string{"a.a.a.a/aa", "b.b.b.b/bb"}
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../..",
+		Vars: map[string]interface{}{
+			"comma_sep_ip_list": "a.a.a.a/aa, b.b.b.b/bb",
+		},
+		NoColor: true,
+	}
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+	actualExampleList := terraform.OutputList(t, terraformOptions, "ips_as_list")
+	assert.Equal(t, expectedList, actualExampleList)
+}
+
+func TestPreservesTailList(t *testing.T) {
+	expectedList := []string{"a.a.a.a/aa", "b.b.b.b/bb", "c.c.c.c/cc"}
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../..",
+		Vars: map[string]interface{}{
+			"comma_sep_ip_list": "a.a.a.a/aa, b.b.b.b/bb",
+			"tail_list":         []string{"c.c.c.c/cc"},
+		},
+		NoColor: true,
+	}
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+	actualExampleList := terraform.OutputList(t, terraformOptions, "ips_as_list")
+	assert.Equal(t, expectedList, actualExampleList)
+}
+
+func TestBlankInputIsEmptyList(t *testing.T) {
+	expectedList := []string{}
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../..",
+		Vars: map[string]interface{}{
+			"comma_sep_ip_list": "",
+		},
+		NoColor: true,
+	}
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+	actualExampleList := terraform.OutputList(t, terraformOptions, "ips_as_list")
+	assert.Equal(t, expectedList, actualExampleList)
+}

--- a/infra/templates/az-isolated-service-single-region/helper-ips/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/helper-ips/variables.tf
@@ -1,6 +1,6 @@
 variable "comma_sep_ip_list" {
   description = "A comma-separated list of IPs and/or CIDR/IP ranges that will be converted to a TF list/array, e.g. \"1.1.1.1/32, 8.8.8.8/24\"."
-  type = string
+  type        = string
 }
 
 variable "tail_list" {
@@ -8,6 +8,6 @@ variable "tail_list" {
     A TF list that will be combined with the `comma_sep_ip_list`, if provided. Items
     from the `comma_sep_ip_list` will appear to the left of items from this `tail_list` value."
 HERE
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }

--- a/infra/templates/az-isolated-service-single-region/helper-ips/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/helper-ips/variables.tf
@@ -1,0 +1,13 @@
+variable "comma_sep_ip_list" {
+  description = "A comma-separated list of IPs and/or CIDR/IP ranges that will be converted to a TF list/array, e.g. \"1.1.1.1/32, 8.8.8.8/24\"."
+  type = string
+}
+
+variable "tail_list" {
+  description = <<HERE
+    A TF list that will be combined with the `comma_sep_ip_list`, if provided. Items
+    from the `comma_sep_ip_list` will appear to the left of items from this `tail_list` value."
+HERE
+  type = list(string)
+  default = []
+}

--- a/infra/templates/az-isolated-service-single-region/terraform.tfvars
+++ b/infra/templates/az-isolated-service-single-region/terraform.tfvars
@@ -28,21 +28,6 @@ unauthn_deployment_targets = [
   }
 ]
 
-# Note: this is configured as such only to test IP Whitelists. This is a well
-# known DNS address
-resource_ip_whitelist = ["13.89.34.162/32",
-  "13.107.6.0/24",
-  "13.107.9.0/24",
-  "13.107.42.0/24",
-  "13.107.43.0/24",
-  "40.74.0.0/15",
-  "40.76.0.0/14",
-  "40.80.0.0/12",
-  "40.96.0.0/12",
-  "40.112.0.0/13",
-  "40.120.0.0/14",
-  "40.124.0.0/16",
-"40.125.0.0/17"]
 ase_name           = "co-static-ase"
 ase_resource_group = "co-static-ase-rg"
 ase_vnet_name      = "co-static-ase-vnet"

--- a/infra/templates/az-isolated-service-single-region/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/variables.tf
@@ -169,9 +169,9 @@ variable "app_dev_subscription_id" {
 // ---- Networking For App Dev Resources ----
 
 variable "resource_ip_whitelist" {
-  description = "A list of IPs and/or IP ranges that should have access to VNET isolated resources provisioned by this template"
-  type        = list(string)
-  default     = []
+  description = "A comma-separated list of IPs and/or IP ranges that should have access to VNET isolated resources provisioned by this template"
+  type        = string
+  default     = "13.89.34.162/32, 13.107.6.0/24, 13.107.9.0/24, 13.107.42.0/24,13.107.43.0/24, 40.74.0.0/15, 40.76.0.0/14, 40.80.0.0/12, 40.96.0.0/12,40.112.0.0/13, 40.120.0.0/14, 40.124.0.0/16, 40.125.0.0/17"
 }
 
 # Note: We won't be supporting monitoring rules until we have more direction from the

--- a/infra/templates/az-isolated-service-single-region/variables.tf
+++ b/infra/templates/az-isolated-service-single-region/variables.tf
@@ -171,7 +171,21 @@ variable "app_dev_subscription_id" {
 variable "resource_ip_whitelist" {
   description = "A comma-separated list of IPs and/or IP ranges that should have access to VNET isolated resources provisioned by this template"
   type        = string
-  default     = "13.89.34.162/32, 13.107.6.0/24, 13.107.9.0/24, 13.107.42.0/24,13.107.43.0/24, 40.74.0.0/15, 40.76.0.0/14, 40.80.0.0/12, 40.96.0.0/12,40.112.0.0/13, 40.120.0.0/14, 40.124.0.0/16, 40.125.0.0/17"
+  default     = <<HEREDOC
+13.89.34.162/32,
+13.107.6.0/24,
+13.107.9.0/24,
+13.107.42.0/24,
+13.107.43.0/24,
+40.74.0.0/15,
+40.76.0.0/14,
+40.80.0.0/12,
+40.96.0.0/12,
+40.112.0.0/13,
+40.120.0.0/14,
+40.124.0.0/16,
+40.125.0.0/17
+HEREDOC
 }
 
 # Note: We won't be supporting monitoring rules until we have more direction from the


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES]I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
ISO template users must provide whitelist IP/CIDR input via the `infra/templates/az-isolated-service-single-region/terraform.tfvars` file (and thus check-in a change to that file to account for their specific self-hosted build agents)

Resolves Issue Number #341 

## What is the new behavior?
-------------------------------------
ISO template users can _optionally_ provide a `TF_VAR_resource_ip_whitelist` environment variable (via many means, including Az Pipeline Variable Groups) to control the whitelist.

Users that do not use the new, optional env var will see the same behavior as before.