### PR TITLE
Disable autoscale when app svc plan module configured for az func

### DIFF
--- a/infra/modules/providers/azure/service-plan/main.tf
+++ b/infra/modules/providers/azure/service-plan/main.tf
@@ -23,6 +23,7 @@ resource "azurerm_monitor_autoscale_setting" "app_service_auto_scale" {
   resource_group_name = var.resource_group_name
   location            = data.azurerm_resource_group.svcplan.location
   target_resource_id  = azurerm_app_service_plan.svcplan.id
+  # Dynamic is the basic plan tier for Azure Function that does not allow custom autoscaling
   count               = var.service_plan_tier == "Dynamic" ? 0 : 1
 
   profile {

--- a/infra/modules/providers/azure/service-plan/main.tf
+++ b/infra/modules/providers/azure/service-plan/main.tf
@@ -23,6 +23,7 @@ resource "azurerm_monitor_autoscale_setting" "app_service_auto_scale" {
   resource_group_name = var.resource_group_name
   location            = data.azurerm_resource_group.svcplan.location
   target_resource_id  = azurerm_app_service_plan.svcplan.id
+  count               = var.service_plan_tier == "Dynamic" ? 0 : 1
 
   profile {
     name = "Scaling Profile"

--- a/infra/modules/providers/azure/service-plan/main.tf
+++ b/infra/modules/providers/azure/service-plan/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_monitor_autoscale_setting" "app_service_auto_scale" {
   location            = data.azurerm_resource_group.svcplan.location
   target_resource_id  = azurerm_app_service_plan.svcplan.id
   # Dynamic is the basic plan tier for Azure Function that does not allow custom autoscaling
-  count               = var.service_plan_tier == "Dynamic" ? 0 : 1
+  count = var.service_plan_tier == "Dynamic" ? 0 : 1
 
   profile {
     name = "Scaling Profile"

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -199,7 +199,7 @@ func TestTemplate(t *testing.T) {
 			"module.authn_app_service.azurerm_app_service.appsvc[0]":                                                                   expectedAppService,
 			"module.app_service.azurerm_app_service_slot.appsvc_staging_slot[0]":                                                       expectedAppServiceSlot,
 			"module.authn_app_service.azurerm_app_service_slot.appsvc_staging_slot[0]":                                                 expectedAppServiceSlot,
-			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale":                                             expectedAutoScalePlan,
+			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale[0]":                                             expectedAutoScalePlan,
 			"module.app_service_keyvault_access_policy.azurerm_key_vault_access_policy.keyvault[0]":                                    expectedAppServiceKVPolicies,
 			"module.authn_app_service_keyvault_access_policy.azurerm_key_vault_access_policy.keyvault[0]":                              expectedAppServiceKVPolicies,
 			"module.keyvault.module.deployment_service_principal_keyvault_access_policies.azurerm_key_vault_access_policy.keyvault[0]": expectedDeploymentServicePrincipalKVPolicies,

--- a/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
+++ b/infra/templates/az-isolated-service-single-region/tests/unit/unit_test.go
@@ -199,7 +199,7 @@ func TestTemplate(t *testing.T) {
 			"module.authn_app_service.azurerm_app_service.appsvc[0]":                                                                   expectedAppService,
 			"module.app_service.azurerm_app_service_slot.appsvc_staging_slot[0]":                                                       expectedAppServiceSlot,
 			"module.authn_app_service.azurerm_app_service_slot.appsvc_staging_slot[0]":                                                 expectedAppServiceSlot,
-			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale[0]":                                             expectedAutoScalePlan,
+			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale[0]":                                          expectedAutoScalePlan,
 			"module.app_service_keyvault_access_policy.azurerm_key_vault_access_policy.keyvault[0]":                                    expectedAppServiceKVPolicies,
 			"module.authn_app_service_keyvault_access_policy.azurerm_key_vault_access_policy.keyvault[0]":                              expectedAppServiceKVPolicies,
 			"module.keyvault.module.deployment_service_principal_keyvault_access_policies.azurerm_key_vault_access_policy.keyvault[0]": expectedDeploymentServicePrincipalKVPolicies,

--- a/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
+++ b/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
@@ -118,7 +118,7 @@ func TestTemplate(t *testing.T) {
 			},
 			"module.app_service.azurerm_app_service.appsvc[0]":                                                                         expectedAppServicePlan,
 			"module.app_gateway.azurerm_application_gateway.appgateway":                                                                expectedAppGatewayPlan,
-			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale[0]":                                             expectedAutoScalePlan,
+			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale[0]":                                          expectedAutoScalePlan,
 			"module.keyvault.module.deployment_service_principal_keyvault_access_policies.azurerm_key_vault_access_policy.keyvault[0]": expectedDeploymentServicePrincipalKVPolicies,
 		},
 	}

--- a/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
+++ b/infra/templates/az-service-single-region/tests/unit/template_unit_test.go
@@ -118,7 +118,7 @@ func TestTemplate(t *testing.T) {
 			},
 			"module.app_service.azurerm_app_service.appsvc[0]":                                                                         expectedAppServicePlan,
 			"module.app_gateway.azurerm_application_gateway.appgateway":                                                                expectedAppGatewayPlan,
-			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale":                                             expectedAutoScalePlan,
+			"module.service_plan.azurerm_monitor_autoscale_setting.app_service_auto_scale[0]":                                             expectedAutoScalePlan,
 			"module.keyvault.module.deployment_service_principal_keyvault_access_policies.azurerm_key_vault_access_policy.keyvault[0]": expectedDeploymentServicePrincipalKVPolicies,
 		},
 	}


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NO] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #366 "Bug: Autoscale prevents 'dynamic' tier Azure Function Support"


## What is the new behavior?
-------------------------------------
<!-- Please describe the behavior or changes that are being added by this PR. -->

- app svc plan modules can now be distinctly configured for azure functions.

## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

![image](https://user-images.githubusercontent.com/10041279/67395671-01fad680-f56c-11e9-90b2-227e00005599.png)
