### PR TITLE
Add App Gateway Extensions

### DIFF
--- a/infra/modules/providers/azure/app-gateway/output.tf
+++ b/infra/modules/providers/azure/app-gateway/output.tf
@@ -21,3 +21,7 @@ output "app_gateway_health_probe_backend_address" {
   value = data.external.app_gw_health.result["address"]
 }
 
+output "resource_group_name" {
+  description = "The resource group name"
+  value       = azurerm_application_gateway.resource_group_name
+}

--- a/infra/modules/providers/azure/app-gateway/tests/.env.testing.template
+++ b/infra/modules/providers/azure/app-gateway/tests/.env.testing.template
@@ -1,0 +1,1 @@
+APP_GATEWAY_NAME="..."

--- a/infra/modules/providers/azure/app-gateway/tests/integration/appgateway.go
+++ b/infra/modules/providers/azure/app-gateway/tests/integration/appgateway.go
@@ -1,17 +1,3 @@
-//  Copyright © Microsoft Corporation
-//
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package integration
 
 import (
@@ -19,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-02-01/network"
-	"github.com/microsoft/cobalt/test-harness/infratests"
 	"github.com/microsoft/cobalt/test-harness/terratest-extensions/modules/azure"
+	"github.com/microsoft/terratest-abstraction/integration"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,8 +44,8 @@ func checkSSLCertificates(t *testing.T, appGatewayProperties *network.Applicatio
 }
 
 // InspectAppGateway - Runs a suite of test assertions to validate properties for an application gateway
-func InspectAppGateway(resourceGroupNameOutput string, appGatewayNameOutput string, keyvaultIDOutput string) func(t *testing.T, output infratests.TerraformOutput) {
-	return func(t *testing.T, output infratests.TerraformOutput) {
+func InspectAppGateway(resourceGroupNameOutput string, appGatewayNameOutput string, keyvaultIDOutput string) func(t *testing.T, output integration.TerraformOutput) {
+	return func(t *testing.T, output integration.TerraformOutput) {
 		appGatewayName := output[appGatewayNameOutput].(string)
 		resourceGroupName := output[resourceGroupNameOutput].(string)
 		keyvaultSecretID := output[keyvaultIDOutput].(string)

--- a/infra/modules/providers/azure/app-gateway/tests/integration/appgateway.go
+++ b/infra/modules/providers/azure/app-gateway/tests/integration/appgateway.go
@@ -1,0 +1,78 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-02-01/network"
+	"github.com/microsoft/cobalt/test-harness/infratests"
+	"github.com/microsoft/cobalt/test-harness/terratest-extensions/modules/azure"
+	"github.com/stretchr/testify/require"
+)
+
+var subscription = os.Getenv("ARM_SUBSCRIPTION_ID")
+
+func checkMinCapactiy(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat) {
+	minCapacity := appGatewayProperties.AutoscaleConfiguration.MinCapacity
+	require.Equal(t, int32(2), *minCapacity)
+}
+
+func checkOWASPRuleset(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat) {
+	firewallRulesetType := appGatewayProperties.WebApplicationFirewallConfiguration.RuleSetType
+	firewallRulesetVersion := appGatewayProperties.WebApplicationFirewallConfiguration.RuleSetVersion
+	require.Equal(t, "OWASP", *firewallRulesetType, "Firewall ruleset type is incorrect")
+	require.Equal(t, "3.1", *firewallRulesetVersion, "Firewall ruleset version is incorrect")
+}
+
+func checkAvailablePorts(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat) {
+	foundPort := false
+	frontendPorts := appGatewayProperties.FrontendPorts
+	for _, frontend := range *frontendPorts {
+		if *frontend.Port == int32(443) {
+			foundPort = true
+		}
+	}
+	require.True(t, foundPort, "Failed to find a frontendPort with port 443")
+}
+
+func checkSSLCertificates(t *testing.T, appGatewayProperties *network.ApplicationGatewayPropertiesFormat, keyvaultSecretID string) {
+	certs := appGatewayProperties.SslCertificates
+	require.Equal(t, 1, len(*certs))
+	cert := (*certs)[0]
+	require.Equal(t, "Succeeded", *cert.ProvisioningState)
+	require.Equal(t, keyvaultSecretID, *cert.KeyVaultSecretID)
+}
+
+// InspectAppGateway - Runs a suite of test assertions to validate properties for an application gateway
+func InspectAppGateway(resourceGroupNameOutput string, appGatewayNameOutput string, keyvaultIDOutput string) func(t *testing.T, output infratests.TerraformOutput) {
+	return func(t *testing.T, output infratests.TerraformOutput) {
+		appGatewayName := output[appGatewayNameOutput].(string)
+		resourceGroupName := output[resourceGroupNameOutput].(string)
+		keyvaultSecretID := output[keyvaultIDOutput].(string)
+
+		appGateway, err := azure.GetAppGatewayProperties(subscription, resourceGroupName, appGatewayName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		appGatewayProperties := appGateway.ApplicationGatewayPropertiesFormat
+
+		checkMinCapactiy(t, appGatewayProperties)
+		checkOWASPRuleset(t, appGatewayProperties)
+		checkSSLCertificates(t, appGatewayProperties, keyvaultSecretID)
+	}
+}

--- a/infra/modules/providers/azure/app-gateway/tests/integration/appgateway_test.go
+++ b/infra/modules/providers/azure/app-gateway/tests/integration/appgateway_test.go
@@ -1,34 +1,20 @@
-//  Copyright © Microsoft Corporation
-//
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package integration
 
 import (
 	"testing"
 
 	"github.com/microsoft/cobalt/infra/modules/providers/azure/app-gateway/tests"
-	"github.com/microsoft/cobalt/test-harness/infratests"
+	"github.com/microsoft/terratest-abstraction/integration"
 )
 
 func TestAppGateway(t *testing.T) {
-	testFixture := infratests.IntegrationTestFixture{
+	testFixture := integration.IntegrationTestFixture{
 		GoTest:                t,
 		TfOptions:             tests.AppGatewayOptions,
 		ExpectedTfOutputCount: 6,
-		TfOutputAssertions: []infratests.TerraformOutputValidation{
+		TfOutputAssertions: []integration.TerraformOutputValidation{
 			InspectAppGateway("resource_group_name", "appgateway_name", "keyvault_secret_id"),
 		},
 	}
-	infratests.RunIntegrationTests(&testFixture)
+	integration.RunIntegrationTests(&testFixture)
 }

--- a/infra/modules/providers/azure/app-gateway/tests/integration/appgateway_test.go
+++ b/infra/modules/providers/azure/app-gateway/tests/integration/appgateway_test.go
@@ -1,0 +1,34 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/microsoft/cobalt/infra/modules/providers/azure/app-gateway/tests"
+	"github.com/microsoft/cobalt/test-harness/infratests"
+)
+
+func TestAppGateway(t *testing.T) {
+	testFixture := infratests.IntegrationTestFixture{
+		GoTest:                t,
+		TfOptions:             tests.AppGatewayOptions,
+		ExpectedTfOutputCount: 6,
+		TfOutputAssertions: []infratests.TerraformOutputValidation{
+			InspectAppGateway("resource_group_name", "appgateway_name", "keyvault_secret_id"),
+		},
+	}
+	infratests.RunIntegrationTests(&testFixture)
+}

--- a/infra/modules/providers/azure/app-gateway/tests/tf_options.go
+++ b/infra/modules/providers/azure/app-gateway/tests/tf_options.go
@@ -1,0 +1,32 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package tests
+
+import (
+	"os"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+// appGatewayName the name of the application gateway
+var appGatewayName = os.Getenv("APP_GATEWAY_NAME")
+
+var AppGatewayOptions = &terraform.Options{
+	TerraformDir: "../../",
+	Upgrade:      true,
+	Vars: map[string]interface{}{
+		"name": appGatewayName,
+	},
+}

--- a/infra/modules/providers/azure/app-gateway/tests/tf_options.go
+++ b/infra/modules/providers/azure/app-gateway/tests/tf_options.go
@@ -1,17 +1,3 @@
-//  Copyright © Microsoft Corporation
-//
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package tests
 
 import (

--- a/test-harness/terratest-extensions/modules/azure/appgateway.go
+++ b/test-harness/terratest-extensions/modules/azure/appgateway.go
@@ -1,0 +1,58 @@
+//  Copyright © Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-02-01/network"
+)
+
+func applicationGatewaysClientE(subscriptionID string) (*network.ApplicationGatewaysClient, error) {
+	authorizer, err := DeploymentServicePrincipalAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+
+	client := network.NewApplicationGatewaysClient(subscriptionID)
+	client.Authorizer = authorizer
+	return &client, nil
+}
+
+func getAppGatewayPropertiesE(client *network.ApplicationGatewaysClient, resourceGroupName string, applicationGatewayName string) (*network.ApplicationGateway, error) { //?
+	ctx := context.Background()
+
+	applicationGateway, err := client.Get(ctx, resourceGroupName, applicationGatewayName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &applicationGateway, nil
+}
+
+// GetAppGatewayProperties - Get properties for an app gateway
+func GetAppGatewayProperties(subscription string, resourceGroupName string, appGatewayName string) (*network.ApplicationGateway, error) {
+	client, err := applicationGatewaysClientE(subscription)
+	if err != nil {
+		return nil, err
+	}
+
+	appGateway, err := getAppGatewayPropertiesE(client, resourceGroupName, appGatewayName)
+	if err != nil {
+		return nil, err
+	}
+
+	return appGateway, nil
+}

--- a/test-harness/terratest-extensions/modules/azure/appgateway.go
+++ b/test-harness/terratest-extensions/modules/azure/appgateway.go
@@ -1,17 +1,3 @@
-//  Copyright © Microsoft Corporation
-//
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package azure
 
 import (


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
The current test harness does not support querying configuration information from an App Gateway resource in Azure.


## What is the new behavior?
-------------------------------------
This PR introduces extensions to the test harness and module level integration tests for App Gateways in Azure.
- Added `test-harness/terratest-extensions/modules/azure/appgateway.go` got querying configuration from an app gateway using the [azure sdk for go](https://github.com/Azure/azure-sdk-for-go/blob/master/services/network/mgmt/2019-02-01/network/applicationgateways.go)
- Added integration tests for app gateways in `infra/modules/providers/azure/app-gateway`
- Added `resource_group_name` as an output in `infra/modules/providers/azure/app-gateway/output.tf`

## Does this introduce a breaking change?
-------------------------------------
- [YES]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
-------------------------------------
N/A

## Other information
-------------------------------------
N/A